### PR TITLE
Add command to increase player level caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/.gradle/
+/.gradle-wrapper/
+/build/
+/out/
+/bin/
+/run/
+gradle/
+*.iml
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# sidemodsrerforged
-SideMods for Reforged
+# Pixelmon Level Cap Mod
+
+This Forge mod adds server-side level caps for Pixelmon Reforged. It enforces configurable caps that increase as trainers earn gym badges. Pokemon above the cap faint automatically when sent into battle, helping keep progression balanced on multiplayer servers.
+
+## Features
+
+* Configurable default level cap and gym-specific caps stored in `config/pixelmon-level-caps.json`.
+* Caps increase whenever a player earns a configured gym badge and persist per-player.
+* When a Pokemon above the cap is sent out in a battle, it immediately faints.
+* `/lvlcap` command lets players view their current cap and the next configured upgrade.
+* `/lvlcap faint` lets players or admins immediately faint party Pokemon that exceed the current cap.
+* Admin subcommands (`/lvlcap set`, `/lvlcap remove`, `/lvlcap list`) manage gym caps by gym or gym leader name.
+* `/lvlcap increase <player> <level>` raises a trainer's cap to at least the supplied value without editing gym configs.
+* Admins can instantly spawn and bind a gym NPC with `/lvlcap spawn <name> <level> [reward items]`, optionally granting items for victories.
+* Admins can create new gyms with `/create gym <name> <level>` and bind them to Pixelmon NPCs by right-clicking the intended leader.
+
+## Commands
+
+| Command | Description |
+| --- | --- |
+| `/lvlcap` | Shows the caller's current cap and the next configured milestone. |
+| `/lvlcap faint [player]` | Faints the caller's over-cap Pixelmon. (Permission level 2+ to target another player.) |
+| `/lvlcap set <gym> <level>` | (Permission level 2+) Sets the cap for the given gym/leader name. |
+| `/lvlcap remove <gym>` | (Permission level 2+) Removes the configured cap for the given gym. |
+| `/lvlcap increase <player> <level>` | (Permission level 2+) Raises the target's cap to at least the requested level. |
+| `/lvlcap list` | (Permission level 2+) Lists all configured gym caps. |
+| `/lvlcap spawn <gym> <level> [rewards]` | (Permission level 2+) Spawns a Pixelmon NPC in front of you, binds it as a gym with the given cap, and optionally configures victory rewards. |
+| `/create gym <name> <level>` | (Permission level 2+) Starts gym creation; right-click a Pixelmon NPC to finalise the binding. |
+
+Players automatically receive chat updates whenever their cap changes or when a high-level Pokemon is forced to faint. Gym victories can now also award configured items when the gym is created with rewards.
+
+### Permission nodes
+
+The mod registers the following permission nodes via Forge's `PermissionAPI` so server owners can integrate with LuckPerms or similar managers:
+
+| Node | Default | Description |
+| --- | --- | --- |
+| `lvlcap.command.view` | Everyone | Allows viewing your current cap with `/lvlcap`. |
+| `lvlcap.command.faint` | Everyone | Allows using `/lvlcap faint` on yourself. |
+| `lvlcap.command.faint.others` | OPs | Allows fainting other players' Pokémon with `/lvlcap faint <player>`. |
+| `lvlcap.command.set` | OPs | Allows setting gym caps with `/lvlcap set`. |
+| `lvlcap.command.remove` | OPs | Allows removing gym caps with `/lvlcap remove`. |
+| `lvlcap.command.increase` | OPs | Allows raising player caps with `/lvlcap increase`. |
+| `lvlcap.command.list` | OPs | Allows listing configured caps with `/lvlcap list`. |
+| `lvlcap.command.spawn` | OPs | Allows spawning and configuring gym NPCs with `/lvlcap spawn`. |
+| `lvlcap.command.create` | OPs | Allows creating gyms with `/create gym`. |
+
+### Reward syntax
+
+When using `/lvlcap spawn`, append space-separated item identifiers to award them on gym victory. Each token can optionally use `*` to specify a quantity. For example:
+
+```
+/lvlcap spawn Electric 50 pixelmon:rare_candy*5 minecraft:nether_star
+```
+
+This spawns the gym with a level cap of 50 and delivers five Rare Candies plus a Nether Star the first time a player defeats the gym. Rewards are saved to `pixelmon-level-caps.json` alongside the gym definition.
+
+## Building
+
+This project uses ForgeGradle for Minecraft 1.16.5 and therefore must be
+compiled with Java 8.
+
+1. Install a Java 8 JDK (for example, Temurin/Adoptium 8) and make sure it is
+   the active JVM on your shell (`java -version` should report 1.8).
+2. Clone this repository and open a terminal in the project directory.
+3. Use the provided bootstrap scripts to run Gradle 7.6.3 (the newest release
+   supported by ForgeGradle 5) without installing it system-wide:
+   * Unix/macOS: `./gradlew build`
+   * Windows: `gradle.bat build`
+   The first run downloads Gradle into `.gradle-wrapper/` and all subsequent
+   invocations reuse that copy. If you prefer to install Gradle manually, make
+   sure you invoke version 7.6.3—ForgeGradle 5 will fail to apply on Gradle 8.x.
+4. The reobfuscated release jar will be copied to
+   `build/libs/pixelmon-level-cap-0.1.0-release.jar` after the build finishes.
+   (The deobfuscated development jar still lives at
+   `build/libs/pixelmon-level-cap-0.1.0.jar`.)
+
+Copy that jar into the `mods/` folder on your Forge server or client alongside
+Pixelmon Reforged to enable the level-cap behaviour.
+
+## Configuration
+
+* `config/pixelmon-level-caps.json` – JSON file storing default cap and per-gym caps.
+* `serverconfig/lvlcap-server.toml` – Forge config controlling the default cap before any badges.
+
+Caps update immediately when gym data changes or when admins edit the config files.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,102 @@
+buildscript {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'net.minecraftforge.gradle:ForgeGradle:5.1+'
+    }
+}
+
+apply plugin: 'net.minecraftforge.gradle'
+apply plugin: 'eclipse'
+apply plugin: 'maven-publish'
+
+version = '0.1.0'
+group = 'com.example.pixelmon'
+archivesBaseName = 'pixelmon-level-cap'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
+minecraft {
+    mappings channel: 'official', version: '1.16.5'
+
+    runs {
+        client {
+            workingDirectory project.file('run')
+            mods {
+                lvlcap {
+                    source sourceSets.main
+                }
+            }
+        }
+        server {
+            workingDirectory project.file('run')
+            mods {
+                lvlcap {
+                    source sourceSets.main
+                }
+            }
+        }
+    }
+}
+
+repositories {
+    maven { url = 'https://maven.minecraftforge.net' }
+    mavenCentral()
+}
+
+dependencies {
+    minecraft 'net.minecraftforge:forge:1.16.5-36.2.39'
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir 'src/generated/resources'
+        }
+    }
+}
+
+jar {
+    manifest {
+        attributes([
+                'Specification-Title'   : 'Pixelmon Level Cap',
+                'Specification-Vendor'  : 'sidemodsrerforged',
+                'Specification-Version' : '1',
+                'Implementation-Title'  : project.name,
+                'Implementation-Version': project.version,
+                'Implementation-Vendor' : 'sidemodsrerforged',
+                'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        ])
+    }
+}
+
+jar.finalizedBy('reobfJar')
+
+def jarTask = tasks.named('jar', org.gradle.api.tasks.bundling.Jar)
+def releaseJarName = jarTask.flatMap { jar ->
+    jar.archiveFileName.map { name -> name.replaceFirst(/\.jar$/, '-release.jar') }
+}
+
+tasks.named('reobfJar').configure { reobf ->
+    doLast {
+        if (reobf.outputs.files.isEmpty()) {
+            return
+        }
+        def libsDir = layout.buildDirectory.dir('libs').get().asFile
+        def originalName = jarTask.get().archiveFileName.get()
+        def renamed = releaseJarName.get()
+        project.copy {
+            from reobf.outputs.files
+            into libsDir
+            rename { fileName -> fileName == originalName ? renamed : fileName }
+        }
+        project.logger.lifecycle("Release jar available at ${new File(libsDir, renamed)}")
+    }
+}
+

--- a/gradle.bat
+++ b/gradle.bat
@@ -1,0 +1,55 @@
+@echo off
+setlocal
+
+set "GRADLE_VERSION=7.6.3"
+set "DISTRIBUTION_URL=https://services.gradle.org/distributions/gradle-%GRADLE_VERSION%-bin.zip"
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR%"=="" set "SCRIPT_DIR=.\"
+set "WRAPPER_DIR=%SCRIPT_DIR%.gradle-wrapper"
+set "DIST_ZIP=%WRAPPER_DIR%\gradle-%GRADLE_VERSION%-bin.zip"
+set "GRADLE_HOME=%WRAPPER_DIR%\gradle-%GRADLE_VERSION%"
+set "GRADLE_LAUNCHER=%GRADLE_HOME%\bin\gradle.bat"
+
+if not exist "%WRAPPER_DIR%" (
+    mkdir "%WRAPPER_DIR%"
+    if errorlevel 1 (
+        echo Failed to create wrapper cache directory "%WRAPPER_DIR%".
+        exit /b 1
+    )
+)
+
+where powershell >nul 2>nul
+if errorlevel 1 (
+    echo PowerShell is required to bootstrap Gradle automatically.
+    echo Download Gradle %GRADLE_VERSION% manually from:
+    echo   %DISTRIBUTION_URL%
+    exit /b 1
+)
+
+if not exist "%DIST_ZIP%" (
+    echo Downloading Gradle %GRADLE_VERSION%...
+    powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "try {Invoke-WebRequest -Uri '%DISTRIBUTION_URL%' -OutFile '%DIST_ZIP%' -UseBasicParsing} catch {Write-Error $_; exit 1}"
+    if errorlevel 1 (
+        echo Failed to download Gradle distribution.
+        exit /b 1
+    )
+)
+
+if not exist "%GRADLE_LAUNCHER%" (
+    echo Extracting Gradle %GRADLE_VERSION%...
+    powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "try {Expand-Archive -LiteralPath '%DIST_ZIP%' -DestinationPath '%WRAPPER_DIR%' -Force} catch {Write-Error $_; exit 1}"
+    if errorlevel 1 (
+        echo Failed to extract Gradle distribution.
+        exit /b 1
+    )
+)
+
+if not exist "%GRADLE_LAUNCHER%" (
+    echo Gradle launcher not found at "%GRADLE_LAUNCHER%".
+    exit /b 1
+)
+
+call "%GRADLE_LAUNCHER%" %*
+set "EXIT_CODE=%ERRORLEVEL%"
+endlocal & exit /b %EXIT_CODE%

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Sets default memory used for gradle commands. Can be overridden.
+org.gradle.jvmargs=-Xmx3G

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+
+set -eu
+
+GRADLE_VERSION="7.6.3"
+DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
+WRAPPER_DIR="${SCRIPT_DIR}/.gradle-wrapper"
+DIST_ZIP="${WRAPPER_DIR}/gradle-${GRADLE_VERSION}-bin.zip"
+GRADLE_HOME="${WRAPPER_DIR}/gradle-${GRADLE_VERSION}"
+GRADLE_LAUNCHER="${GRADLE_HOME}/bin/gradle"
+
+mkdir -p "${WRAPPER_DIR}"
+
+download_distribution() {
+    printf 'Downloading Gradle %s...\n' "${GRADLE_VERSION}" >&2
+    if command -v curl >/dev/null 2>&1; then
+        curl -fLso "${DIST_ZIP}" "${DISTRIBUTION_URL}"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "${DIST_ZIP}" "${DISTRIBUTION_URL}"
+    else
+        printf 'Neither curl nor wget is available to download Gradle.\n' >&2
+        printf 'Download %s manually and place it at %s.\n' "${DISTRIBUTION_URL}" "${DIST_ZIP}" >&2
+        exit 1
+    fi
+}
+
+extract_distribution() {
+    printf 'Extracting Gradle %s...\n' "${GRADLE_VERSION}" >&2
+    rm -rf "${GRADLE_HOME}"
+    if command -v unzip >/dev/null 2>&1; then
+        unzip -q "${DIST_ZIP}" -d "${WRAPPER_DIR}"
+    elif command -v jar >/dev/null 2>&1; then
+        (cd "${WRAPPER_DIR}" && jar xf "${DIST_ZIP}")
+    else
+        printf 'Neither unzip nor jar is available to extract the Gradle distribution.\n' >&2
+        printf 'Install unzip or ensure the JDK jar tool is on your PATH.\n' >&2
+        exit 1
+    fi
+}
+
+if [ ! -f "${DIST_ZIP}" ]; then
+    download_distribution
+fi
+
+if [ ! -x "${GRADLE_LAUNCHER}" ]; then
+    extract_distribution
+fi
+
+if [ ! -x "${GRADLE_LAUNCHER}" ]; then
+    printf 'Gradle launcher not found at %s after extraction.\n' "${GRADLE_LAUNCHER}" >&2
+    exit 1
+fi
+
+exec "${GRADLE_LAUNCHER}" "$@"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pixelmon-level-cap'

--- a/src/main/java/com/example/lvlcap/GymLevelCapConfig.java
+++ b/src/main/java/com/example/lvlcap/GymLevelCapConfig.java
@@ -1,0 +1,555 @@
+package com.example.lvlcap;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class GymLevelCapConfig {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String DEFAULT_GYM_ID = "gym";
+    private static final Pattern COLOR_CODE_PATTERN = Pattern.compile("(?i)[\\u00A7&][0-9A-FK-ORX]");
+    private static final Set<String> IGNORED_ALIAS_TOKENS = new HashSet<>(Arrays.asList(
+            "gym", "leader", "npc", "trainer", "the", "badge"));
+
+    private final Path configFile;
+    private int baseLevelCap;
+    private final Map<String, GymDefinition> gyms = new LinkedHashMap<>();
+    private final Map<String, String> aliases = new HashMap<>();
+
+    public GymLevelCapConfig(Path configDir, int baseLevelCap) {
+        this.configFile = configDir.resolve("pixelmon-level-caps.json");
+        this.baseLevelCap = Math.max(1, baseLevelCap);
+        reload();
+    }
+
+    public synchronized void setBaseLevelCap(int baseLevelCap) {
+        this.baseLevelCap = Math.max(1, baseLevelCap);
+    }
+
+    public synchronized void reload() {
+        gyms.clear();
+        aliases.clear();
+        if (!Files.exists(configFile)) {
+            save();
+            return;
+        }
+        try (BufferedReader reader = Files.newBufferedReader(configFile, StandardCharsets.UTF_8)) {
+            ConfigModel model = GSON.fromJson(reader, ConfigModel.class);
+            if (model != null && model.defaultLevelCap > 0) {
+                this.baseLevelCap = model.defaultLevelCap;
+            }
+            if (model != null && model.gyms != null) {
+                for (GymEntry entry : model.gyms) {
+                    if (entry == null) {
+                        continue;
+                    }
+                    String gymName = trimToNull(entry.name);
+                    String leaderName = trimToNull(entry.leader);
+                    String npcUuid = trimToNull(entry.npcUuid);
+                    int levelCap = entry.levelCap > 0 ? entry.levelCap : this.baseLevelCap;
+                    String id = trimToNull(entry.id);
+                    if (id != null) {
+                        id = normalizeKey(id);
+                    }
+                    if (id == null || id.isEmpty()) {
+                        id = normalizeKey(gymName != null ? gymName : leaderName);
+                    }
+                    if (id == null || id.isEmpty()) {
+                        id = npcUuid != null ? normalizeKey(npcUuid) : null;
+                    }
+                    id = ensureUniqueId(id);
+                    GymDefinition definition = new GymDefinition();
+                    definition.id = id;
+                    definition.gymName = gymName;
+                    definition.leaderName = leaderName;
+                    definition.npcUuid = npcUuid;
+                    definition.levelCap = levelCap;
+                    definition.rewards.clear();
+                    if (entry.rewards != null) {
+                        for (RewardEntry rewardEntry : entry.rewards) {
+                            if (rewardEntry == null) {
+                                continue;
+                            }
+                            ItemReward reward = new ItemReward(rewardEntry.item, rewardEntry.count, rewardEntry.nbt);
+                            if (reward.getItemId() != null) {
+                                definition.rewards.add(reward);
+                            }
+                        }
+                    }
+                    gyms.put(id, definition);
+                    refreshAliasesFor(definition);
+                }
+            }
+        } catch (IOException | JsonParseException e) {
+            LevelCapMod.LOGGER.error("Failed to read gym level cap configuration", e);
+        }
+    }
+
+    public synchronized void save() {
+        ConfigModel model = new ConfigModel();
+        model.defaultLevelCap = baseLevelCap;
+        for (GymDefinition definition : gyms.values()) {
+            GymEntry entry = new GymEntry();
+            entry.id = definition.id;
+            entry.name = definition.gymName;
+            entry.leader = definition.leaderName;
+            entry.npcUuid = definition.npcUuid;
+            entry.levelCap = definition.levelCap;
+            for (ItemReward reward : definition.rewards) {
+                RewardEntry rewardEntry = new RewardEntry();
+                rewardEntry.item = reward.getItemId();
+                rewardEntry.count = reward.getCount();
+                rewardEntry.nbt = reward.getNbt();
+                entry.rewards.add(rewardEntry);
+            }
+            model.gyms.add(entry);
+        }
+        try {
+            Files.createDirectories(configFile.getParent());
+            try (BufferedWriter writer = Files.newBufferedWriter(configFile, StandardCharsets.UTF_8)) {
+                GSON.toJson(model, writer);
+            }
+        } catch (IOException e) {
+            LevelCapMod.LOGGER.error("Failed to write gym level cap configuration", e);
+        }
+    }
+
+    public synchronized int getDefaultLevelCap() {
+        return baseLevelCap;
+    }
+
+    public synchronized OptionalInt getGymLevelCap(String name) {
+        return getGymLevelCapByNormalized(normalizeKey(name));
+    }
+
+    public synchronized OptionalInt getGymLevelCapByNormalized(String normalized) {
+        String id = resolveIdWithFallbacks(normalizeKey(normalized));
+        if (id == null) {
+            return OptionalInt.empty();
+        }
+        GymDefinition definition = gyms.get(id);
+        return definition == null ? OptionalInt.empty() : OptionalInt.of(definition.levelCap);
+    }
+
+    public synchronized GymSummary findGymSummary(String name) {
+        String normalized = normalizeKey(name);
+        String id = resolveIdWithFallbacks(normalized);
+        if (id == null) {
+            return null;
+        }
+        GymDefinition definition = gyms.get(id);
+        return definition == null ? null : definition.toSummary();
+    }
+
+    public synchronized Map<String, Integer> getAllGymCaps() {
+        Map<String, Integer> response = new LinkedHashMap<>();
+        for (GymDefinition definition : gyms.values()) {
+            response.put(buildDisplayLabel(definition), definition.levelCap);
+        }
+        return response;
+    }
+
+    public synchronized int setGymLevelCap(String name, int levelCap) {
+        String normalized = normalizeKey(name);
+        int cappedLevel = Math.max(1, levelCap);
+        String id = resolveIdWithFallbacks(normalized);
+        GymDefinition definition;
+        if (id == null) {
+            id = ensureUniqueId(normalized);
+            definition = new GymDefinition();
+            definition.id = id;
+            definition.levelCap = cappedLevel;
+            definition.gymName = trimToNull(name);
+            gyms.put(id, definition);
+        } else {
+            definition = gyms.get(id);
+            if (definition == null) {
+                definition = new GymDefinition();
+                definition.id = id;
+                gyms.put(id, definition);
+            }
+            definition.levelCap = cappedLevel;
+            String trimmed = trimToNull(name);
+            if (matches(definition.gymName, normalized) || definition.gymName == null) {
+                definition.gymName = trimmed;
+            } else if (matches(definition.leaderName, normalized) || definition.leaderName == null) {
+                definition.leaderName = trimmed;
+            }
+        }
+        refreshAliasesFor(definition);
+        save();
+        return definition.levelCap;
+    }
+
+    public synchronized boolean removeGym(String name) {
+        String id = resolveIdWithFallbacks(normalizeKey(name));
+        if (id == null) {
+            return false;
+        }
+        if (gyms.remove(id) != null) {
+            clearAliasesFor(id);
+            save();
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized OptionalInt findNextCap(int currentCap, Collection<String> normalizedBadges) {
+        int candidate = Integer.MAX_VALUE;
+        boolean found = false;
+        for (GymDefinition definition : gyms.values()) {
+            if (hasBadge(normalizedBadges, definition.id)) {
+                continue;
+            }
+            int value = definition.levelCap;
+            if (value > currentCap && value < candidate) {
+                candidate = value;
+                found = true;
+            }
+        }
+        return found ? OptionalInt.of(candidate) : OptionalInt.empty();
+    }
+
+    public synchronized void recordDisplayName(String normalized, String displayName) {
+        String trimmedDisplay = trimToNull(displayName);
+        if (trimmedDisplay == null) {
+            return;
+        }
+        String id = resolveIdWithFallbacks(normalizeKey(normalized));
+        if (id == null) {
+            return;
+        }
+        GymDefinition definition = gyms.get(id);
+        if (definition == null) {
+            return;
+        }
+        if (matches(definition.leaderName, normalizeKey(normalized))) {
+            definition.leaderName = trimmedDisplay;
+        } else if (definition.gymName == null || definition.gymName.isEmpty() || matches(definition.gymName, normalizeKey(normalized))) {
+            definition.gymName = trimmedDisplay;
+        }
+        refreshAliasesFor(definition);
+    }
+
+    public synchronized GymSummary createGym(String gymName, String leaderName, String npcUuid, int levelCap) {
+        return createGym(gymName, leaderName, npcUuid, levelCap, Collections.emptyList());
+    }
+
+    public synchronized GymSummary createGym(String gymName, String leaderName, String npcUuid, int levelCap,
+                                             List<ItemReward> rewards) {
+        String trimmedGym = trimToNull(gymName);
+        String trimmedLeader = trimToNull(leaderName);
+        String trimmedNpc = trimToNull(npcUuid);
+        int cappedLevel = Math.max(1, levelCap);
+
+        String id = resolveIdWithFallbacks(normalizeKey(trimmedNpc));
+        if (id == null) {
+            id = resolveIdWithFallbacks(normalizeKey(trimmedGym));
+        }
+        if (id == null) {
+            id = resolveIdWithFallbacks(normalizeKey(trimmedLeader));
+        }
+        if (id == null) {
+            id = ensureUniqueId(normalizeKey(trimmedGym));
+        }
+        GymDefinition definition = gyms.get(id);
+        if (definition == null) {
+            definition = new GymDefinition();
+            definition.id = id;
+            gyms.put(id, definition);
+        }
+        definition.levelCap = cappedLevel;
+        if (trimmedGym != null) {
+            definition.gymName = trimmedGym;
+        }
+        if (trimmedLeader != null) {
+            definition.leaderName = trimmedLeader;
+        }
+        if (trimmedNpc != null) {
+            definition.npcUuid = trimmedNpc;
+        }
+        definition.rewards.clear();
+        if (rewards != null) {
+            for (ItemReward reward : rewards) {
+                if (reward == null || reward.getItemId() == null) {
+                    continue;
+                }
+                definition.rewards.add(reward.copy());
+            }
+        }
+        refreshAliasesFor(definition);
+        save();
+        return definition.toSummary();
+    }
+
+    public String normalizeKey(String name) {
+        if (name == null) {
+            return "";
+        }
+        String stripped = stripFormatting(name);
+        return stripped.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String ensureUniqueId(String base) {
+        String normalizedBase = normalizeKey(base);
+        if (normalizedBase.isEmpty()) {
+            normalizedBase = DEFAULT_GYM_ID;
+        }
+        String candidate = normalizedBase;
+        int counter = 2;
+        while (gyms.containsKey(candidate)) {
+            candidate = normalizedBase + "_" + counter++;
+        }
+        return candidate;
+    }
+
+    private void refreshAliasesFor(GymDefinition definition) {
+        if (definition == null) {
+            return;
+        }
+        clearAliasesFor(definition.id);
+        addAlias(definition.id, definition.id);
+        addAlias(definition.gymName, definition.id);
+        addAlias(definition.leaderName, definition.id);
+        addAlias(definition.npcUuid, definition.id);
+    }
+
+    private void clearAliasesFor(String id) {
+        aliases.entrySet().removeIf(entry -> entry.getValue().equals(id));
+    }
+
+    private void addAlias(String alias, String id) {
+        if (alias == null || id == null) {
+            return;
+        }
+        String normalized = normalizeKey(alias);
+        if (!normalized.isEmpty()) {
+            aliases.put(normalized, id);
+            addAliasTokens(normalized, id);
+        }
+    }
+
+    private void addAliasTokens(String normalized, String id) {
+        if (normalized.indexOf('-') >= 0 && normalized.chars().allMatch(ch -> ch == '-' || (ch >= '0' && ch <= '9')
+                || (ch >= 'a' && ch <= 'f'))) {
+            return;
+        }
+        String[] tokens = normalized.split("[^a-z0-9]+");
+        for (String token : tokens) {
+            if (token.isEmpty() || token.length() < 3 || IGNORED_ALIAS_TOKENS.contains(token)) {
+                continue;
+            }
+            aliases.putIfAbsent(token, id);
+        }
+    }
+
+    private String resolveId(String normalized) {
+        if (normalized == null || normalized.isEmpty()) {
+            return null;
+        }
+        return aliases.get(normalized);
+    }
+
+    private String resolveIdWithFallbacks(String normalized) {
+        String id = resolveId(normalized);
+        if (id != null || normalized == null || normalized.isEmpty()) {
+            return id;
+        }
+        String[] tokens = normalized.split("[^a-z0-9]+");
+        for (String token : tokens) {
+            if (token.isEmpty() || token.length() < 3) {
+                continue;
+            }
+            if (IGNORED_ALIAS_TOKENS.contains(token)) {
+                continue;
+            }
+            id = resolveId(token);
+            if (id != null) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    private boolean hasBadge(Collection<String> normalizedBadges, String id) {
+        if (normalizedBadges == null || id == null) {
+            return false;
+        }
+        for (String badge : normalizedBadges) {
+            String resolved = resolveId(normalizeKey(badge));
+            if (id.equals(resolved)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matches(String candidate, String normalized) {
+        return candidate != null && normalizeKey(candidate).equals(normalized);
+    }
+
+    private String buildDisplayLabel(GymDefinition definition) {
+        String gymName = definition.gymName;
+        String leaderName = definition.leaderName;
+        if (gymName == null || gymName.isEmpty()) {
+            if (leaderName != null && !leaderName.isEmpty()) {
+                return leaderName;
+            }
+            return definition.id;
+        }
+        if (leaderName != null && !leaderName.isEmpty()) {
+            String normalizedGym = normalizeKey(gymName);
+            String normalizedLeader = normalizeKey(leaderName);
+            if (!normalizedGym.equals(normalizedLeader)) {
+                return gymName + " (Leader: " + leaderName + ")";
+            }
+        }
+        return gymName;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static String stripFormatting(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        return COLOR_CODE_PATTERN.matcher(value).replaceAll("");
+    }
+
+    private static List<ItemReward> copyRewards(List<ItemReward> source) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ItemReward> copy = new ArrayList<>();
+        for (ItemReward reward : source) {
+            if (reward == null || reward.getItemId() == null) {
+                continue;
+            }
+            copy.add(reward.copy());
+        }
+        return copy;
+    }
+
+    private static class GymDefinition {
+        private String id;
+        private String gymName;
+        private String leaderName;
+        private String npcUuid;
+        private int levelCap;
+        private final List<ItemReward> rewards = new ArrayList<>();
+
+        private GymSummary toSummary() {
+            return new GymSummary(id, gymName, leaderName, levelCap, copyRewards(rewards));
+        }
+    }
+
+    public static final class GymSummary {
+        private final String id;
+        private final String gymName;
+        private final String leaderName;
+        private final int levelCap;
+        private final List<ItemReward> rewards;
+
+        private GymSummary(String id, String gymName, String leaderName, int levelCap, List<ItemReward> rewards) {
+            this.id = id;
+            this.gymName = gymName;
+            this.leaderName = leaderName;
+            this.levelCap = levelCap;
+            this.rewards = Collections.unmodifiableList(rewards);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getGymName() {
+            return gymName;
+        }
+
+        public String getLeaderName() {
+            return leaderName;
+        }
+
+        public int getLevelCap() {
+            return levelCap;
+        }
+
+        public List<ItemReward> getRewards() {
+            return rewards;
+        }
+    }
+
+    public static final class ItemReward {
+        private final String itemId;
+        private final int count;
+        private final String nbt;
+
+        public ItemReward(String itemId, int count, String nbt) {
+            this.itemId = trimToNull(itemId);
+            this.count = Math.max(1, count);
+            this.nbt = trimToNull(nbt);
+        }
+
+        public String getItemId() {
+            return itemId;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public String getNbt() {
+            return nbt;
+        }
+
+        private ItemReward copy() {
+            return new ItemReward(itemId, count, nbt);
+        }
+    }
+
+    private static class ConfigModel {
+        int defaultLevelCap;
+        List<GymEntry> gyms = new ArrayList<>();
+    }
+
+    private static class GymEntry {
+        String id;
+        String name;
+        String leader;
+        String npcUuid;
+        int levelCap;
+        List<RewardEntry> rewards = new ArrayList<>();
+    }
+
+    private static class RewardEntry {
+        String item;
+        int count = 1;
+        String nbt;
+    }
+}

--- a/src/main/java/com/example/lvlcap/LevelCapCommands.java
+++ b/src/main/java/com/example/lvlcap/LevelCapCommands.java
@@ -1,0 +1,310 @@
+package com.example.lvlcap;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.command.arguments.EntityArgument;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
+
+public final class LevelCapCommands {
+    private LevelCapCommands() {
+    }
+
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        LiteralArgumentBuilder<CommandSource> root = Commands.literal("lvlcap")
+                .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_VIEW))
+                .executes(ctx -> showCap(ctx.getSource()))
+                .then(Commands.literal("faint")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_FAINT_SELF))
+                        .executes(ctx -> faintOverCap(ctx.getSource()))
+                        .then(Commands.argument("player", EntityArgument.player())
+                                .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_FAINT_OTHERS, 2))
+                                .executes(ctx -> faintOverCap(ctx.getSource(),
+                                        EntityArgument.getPlayer(ctx, "player")))))
+                .then(Commands.literal("set")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_SET, 2))
+                        .then(Commands.argument("gym", StringArgumentType.string())
+                                .then(Commands.argument("level", IntegerArgumentType.integer(1))
+                                        .executes(ctx -> setLevelCap(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "gym"),
+                                                IntegerArgumentType.getInteger(ctx, "level"))))))
+                .then(Commands.literal("increase")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_INCREASE, 2))
+                        .then(Commands.argument("player", EntityArgument.player())
+                                .then(Commands.argument("level", IntegerArgumentType.integer(1))
+                                        .executes(ctx -> increaseLevelCap(ctx.getSource(),
+                                                EntityArgument.getPlayer(ctx, "player"),
+                                                IntegerArgumentType.getInteger(ctx, "level"))))))
+                .then(Commands.literal("remove")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_REMOVE, 2))
+                        .then(Commands.argument("gym", StringArgumentType.string())
+                                .executes(ctx -> removeLevelCap(ctx.getSource(),
+                                        StringArgumentType.getString(ctx, "gym")))))
+                .then(Commands.literal("spawn")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_SPAWN, 2))
+                        .then(Commands.argument("gym", StringArgumentType.string())
+                                .then(Commands.argument("level", IntegerArgumentType.integer(1))
+                                        .executes(ctx -> spawnGym(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "gym"),
+                                                IntegerArgumentType.getInteger(ctx, "level")))
+                                        .then(Commands.argument("rewards", StringArgumentType.greedyString())
+                                                .executes(ctx -> spawnGym(ctx.getSource(),
+                                                        StringArgumentType.getString(ctx, "gym"),
+                                                        IntegerArgumentType.getInteger(ctx, "level"),
+                                                        StringArgumentType.getString(ctx, "rewards")))))))
+                .then(Commands.literal("list")
+                        .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_LIST, 2))
+                        .executes(ctx -> listCaps(ctx.getSource())));
+        dispatcher.register(root);
+        dispatcher.register(Commands.literal("create")
+                .requires(source -> PermissionNodes.canUse(source, PermissionNodes.COMMAND_CREATE, 2))
+                .then(Commands.literal("gym")
+                        .then(Commands.argument("name", StringArgumentType.string())
+                                .then(Commands.argument("level", IntegerArgumentType.integer(1))
+                                        .executes(ctx -> createGym(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "name"),
+                                                IntegerArgumentType.getInteger(ctx, "level")))))));
+    }
+
+    private static int showCap(CommandSource source) throws CommandSyntaxException {
+        ServerPlayerEntity player = source.getPlayerOrException();
+        int cap = LevelCapManager.getLevelCap(player);
+        source.sendSuccess(new StringTextComponent("Your Pixelmon level cap is " + cap + "."), false);
+        OptionalInt nextCap = LevelCapManager.getNextCap(player);
+        nextCap.ifPresent(value -> source.sendSuccess(new StringTextComponent("Next configured cap: " + value + "."), false));
+        return cap;
+    }
+
+    private static int setLevelCap(CommandSource source, String gymName, int levelCap) {
+        int stored = LevelCapManager.getConfig().setGymLevelCap(gymName, levelCap);
+        source.sendSuccess(new StringTextComponent("Set level cap for " + gymName + " to " + stored + "."), true);
+        LevelCapManager.handleAllOnlinePlayers(LevelCapManager::broadcastLevelCap);
+        return stored;
+    }
+
+    private static int increaseLevelCap(CommandSource source, ServerPlayerEntity target, int requestedLevel) {
+        int current = LevelCapManager.getLevelCap(target);
+        int desired = Math.max(1, requestedLevel);
+        int newCap = Math.max(current, desired);
+        LevelCapManager.setManualLevelCap(target, newCap);
+        LevelCapManager.broadcastLevelCap(target);
+        if (newCap > current) {
+            source.sendSuccess(new StringTextComponent("Increased " + target.getName().getString()
+                    + "'s level cap to " + newCap + "."), true);
+            if (source.getEntity() != target) {
+                target.sendMessage(new StringTextComponent("Your Pixelmon level cap was increased to " + newCap + "."),
+                        target.getUUID());
+            }
+        } else {
+            source.sendSuccess(new StringTextComponent(target.getName().getString()
+                    + " already has a level cap of " + newCap + " or higher."), false);
+        }
+        return newCap;
+    }
+
+    private static int removeLevelCap(CommandSource source, String gymName) {
+        boolean removed = LevelCapManager.getConfig().removeGym(gymName);
+        if (removed) {
+            source.sendSuccess(new StringTextComponent("Removed level cap for " + gymName + "."), true);
+            LevelCapManager.handleAllOnlinePlayers(LevelCapManager::broadcastLevelCap);
+            return 1;
+        }
+        source.sendSuccess(new StringTextComponent("No configured level cap found for " + gymName + "."), false);
+        return 0;
+    }
+
+    private static int listCaps(CommandSource source) {
+        Map<String, Integer> caps = LevelCapManager.getConfig().getAllGymCaps();
+        if (caps.isEmpty()) {
+            source.sendSuccess(new StringTextComponent("No gym level caps have been configured."), false);
+            return 0;
+        }
+        source.sendSuccess(new StringTextComponent("Configured gym level caps:"), false);
+        caps.forEach((name, level) -> source.sendSuccess(new StringTextComponent(" - " + name + ": " + level), false));
+        return caps.size();
+    }
+
+    private static int spawnGym(CommandSource source, String gymName, int levelCap) throws CommandSyntaxException {
+        return spawnGym(source, gymName, levelCap, null);
+    }
+
+    private static int spawnGym(CommandSource source, String gymName, int levelCap, String rewardSpec) throws CommandSyntaxException {
+        GymLevelCapConfig config = LevelCapManager.getConfig();
+        if (config == null) {
+            source.sendFailure(new StringTextComponent("The level cap configuration is not loaded yet."));
+            return 0;
+        }
+        ServerPlayerEntity player = source.getPlayerOrException();
+        String trimmed = gymName == null ? "" : gymName.trim();
+        String displayGym = trimmed.isEmpty() ? "Gym" : trimmed;
+        int storedLevel = Math.max(1, levelCap);
+        String leaderName = displayGym.equals("Gym") ? "Gym Leader" : displayGym + " Leader";
+        RewardParseResult parseResult = parseRewardSpec(rewardSpec);
+        Entity npc = PixelmonHooks.spawnGymNpc(player, displayGym, leaderName, storedLevel);
+        if (npc == null) {
+            source.sendFailure(new StringTextComponent("Unable to spawn a Pixelmon gym NPC. Ensure Pixelmon is installed."));
+            return 0;
+        }
+        GymLevelCapConfig.GymSummary summary = config.createGym(displayGym, leaderName,
+                npc.getUUID().toString(), storedLevel, parseResult.getRewards());
+        String gymLabel = summary.getGymName();
+        if (gymLabel == null || gymLabel.isEmpty()) {
+            gymLabel = displayGym;
+        }
+        String leaderLabel = summary.getLeaderName();
+        if (leaderLabel == null || leaderLabel.isEmpty()) {
+            leaderLabel = PixelmonHooks.getNpcLeaderName(npc);
+        }
+        StringBuilder message = new StringBuilder("Spawned gym \"")
+                .append(gymLabel)
+                .append("\" led by \"")
+                .append(leaderLabel)
+                .append("\" with a level cap of ")
+                .append(summary.getLevelCap())
+                .append('.');
+        List<GymLevelCapConfig.ItemReward> savedRewards = summary.getRewards();
+        if (!savedRewards.isEmpty()) {
+            String rewardsText = savedRewards.stream()
+                    .map(LevelCapCommands::describeReward)
+                    .collect(Collectors.joining(", "));
+            message.append(" Rewards: ").append(rewardsText).append('.');
+        }
+        source.sendSuccess(new StringTextComponent(message.toString()), true);
+        if (!parseResult.getInvalidTokens().isEmpty()) {
+            source.sendSuccess(new StringTextComponent("Ignored invalid reward entries: "
+                    + String.join(", ", parseResult.getInvalidTokens()) + "."), false);
+        }
+        LevelCapManager.handleAllOnlinePlayers(LevelCapManager::broadcastLevelCap);
+        return 1;
+    }
+
+    private static int faintOverCap(CommandSource source) throws CommandSyntaxException {
+        ServerPlayerEntity player = source.getPlayerOrException();
+        return faintOverCap(source, player);
+    }
+
+    private static int faintOverCap(CommandSource source, ServerPlayerEntity target) {
+        int cap = LevelCapManager.getLevelCap(target);
+        java.util.List<String> fainted = LevelCapManager.faintOverCapPokemon(target);
+        if (fainted.isEmpty()) {
+            if (source.getEntity() == target) {
+                source.sendSuccess(new StringTextComponent("All of your Pixelmon are within the level cap of " + cap + "."), false);
+            } else {
+                source.sendSuccess(new StringTextComponent(target.getName().getString()
+                        + " has no Pixelmon above the level cap of " + cap + "."), true);
+            }
+            return 0;
+        }
+        String joined = String.join(", ", fainted);
+        boolean same = source.getEntity() == target;
+        if (same) {
+            source.sendSuccess(new StringTextComponent("Fainted " + fainted.size()
+                    + " of your Pixelmon above the level cap of " + cap + ": " + joined + "."), false);
+        } else {
+            source.sendSuccess(new StringTextComponent("Fainted " + fainted.size() + " of "
+                    + target.getName().getString() + "'s Pixelmon above the level cap of " + cap + ": " + joined + "."), true);
+            target.sendMessage(new StringTextComponent("Your Pixelmon above the level cap of " + cap
+                    + " were fainted: " + joined + "."), target.getUUID());
+        }
+        return fainted.size();
+    }
+
+    private static String describeReward(GymLevelCapConfig.ItemReward reward) {
+        if (reward == null || reward.getItemId() == null) {
+            return "";
+        }
+        int count = Math.max(1, reward.getCount());
+        if (count == 1) {
+            return reward.getItemId();
+        }
+        return count + "x " + reward.getItemId();
+    }
+
+    private static int createGym(CommandSource source, String gymName, int levelCap) throws CommandSyntaxException {
+        ServerPlayerEntity player = source.getPlayerOrException();
+        String trimmedName = gymName.trim();
+        String displayName = trimmedName.isEmpty() ? "gym" : trimmedName;
+        int storedLevel = Math.max(1, levelCap);
+        LevelCapManager.beginGymCreation(player, trimmedName, storedLevel);
+        source.sendSuccess(new StringTextComponent("Right-click the gym leader NPC to bind \"" + displayName +
+                "\" with a level cap of " + storedLevel + "."), false);
+        return 1;
+    }
+
+    private static RewardParseResult parseRewardSpec(String rewardSpec) {
+        List<GymLevelCapConfig.ItemReward> rewards = new ArrayList<>();
+        List<String> invalid = new ArrayList<>();
+        if (rewardSpec == null) {
+            return new RewardParseResult(rewards, invalid);
+        }
+        String trimmed = rewardSpec.trim();
+        if (trimmed.isEmpty()) {
+            return new RewardParseResult(rewards, invalid);
+        }
+        String[] tokens = trimmed.split("\\s+");
+        for (String token : tokens) {
+            String value = token.trim();
+            if (value.isEmpty()) {
+                continue;
+            }
+            int count = 1;
+            String itemId = value;
+            int starIndex = value.indexOf('*');
+            if (starIndex >= 0) {
+                itemId = value.substring(0, starIndex).trim();
+                String countPart = value.substring(starIndex + 1).trim();
+                if (itemId.isEmpty() || countPart.isEmpty()) {
+                    invalid.add(value);
+                    continue;
+                }
+                try {
+                    count = Integer.parseInt(countPart);
+                } catch (NumberFormatException ex) {
+                    invalid.add(value);
+                    continue;
+                }
+            }
+            if (itemId.isEmpty()) {
+                invalid.add(value);
+                continue;
+            }
+            GymLevelCapConfig.ItemReward reward = new GymLevelCapConfig.ItemReward(itemId, count, null);
+            if (reward.getItemId() == null) {
+                invalid.add(value);
+                continue;
+            }
+            rewards.add(reward);
+        }
+        return new RewardParseResult(rewards, invalid);
+    }
+
+    private static final class RewardParseResult {
+        private final List<GymLevelCapConfig.ItemReward> rewards;
+        private final List<String> invalidTokens;
+
+        private RewardParseResult(List<GymLevelCapConfig.ItemReward> rewards, List<String> invalidTokens) {
+            this.rewards = rewards;
+            this.invalidTokens = invalidTokens;
+        }
+
+        public List<GymLevelCapConfig.ItemReward> getRewards() {
+            return rewards;
+        }
+
+        public List<String> getInvalidTokens() {
+            return invalidTokens;
+        }
+    }
+}

--- a/src/main/java/com/example/lvlcap/LevelCapManager.java
+++ b/src/main/java/com/example/lvlcap/LevelCapManager.java
@@ -1,0 +1,509 @@
+package com.example.lvlcap;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.StringNBT;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.ResourceLocationException;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class LevelCapManager {
+    private static final String PLAYER_DATA_TAG = LevelCapMod.MOD_ID;
+    private static final String PLAYER_BADGES_TAG = "badges";
+    private static final String PLAYER_MANUAL_CAP_TAG = "manualCap";
+
+    private static GymLevelCapConfig config;
+    private static final Map<UUID, PendingGymCreation> pendingGymCreations = new ConcurrentHashMap<>();
+
+    private LevelCapManager() {
+    }
+
+    public static void initialize(Path configDir) {
+        if (config == null) {
+            config = new GymLevelCapConfig(configDir, ModConfigHolder.getBaseLevelCap());
+        } else {
+            config.setBaseLevelCap(ModConfigHolder.getBaseLevelCap());
+            config.reload();
+        }
+    }
+
+    public static void reload() {
+        if (config != null) {
+            config.setBaseLevelCap(ModConfigHolder.getBaseLevelCap());
+            config.reload();
+        }
+    }
+
+    public static void saveConfig() {
+        if (config != null) {
+            config.save();
+        }
+    }
+
+    public static GymLevelCapConfig getConfig() {
+        return config;
+    }
+
+    public static int getLevelCap(ServerPlayerEntity player) {
+        Set<String> badges = getStoredBadges(player);
+        int cap = computeLevelCap(badges);
+        OptionalInt manual = getManualLevelCap(player);
+        if (manual.isPresent()) {
+            cap = Math.max(cap, manual.getAsInt());
+        }
+        return cap;
+    }
+
+    public static int computeLevelCap(Collection<String> normalizedBadges) {
+        int cap = config.getDefaultLevelCap();
+        for (String badge : normalizedBadges) {
+            OptionalInt value = config.getGymLevelCapByNormalized(badge);
+            if (value.isPresent()) {
+                cap = Math.max(cap, value.getAsInt());
+            }
+        }
+        return cap;
+    }
+
+    public static OptionalInt getNextCap(ServerPlayerEntity player) {
+        Set<String> badges = getStoredBadges(player);
+        int current = computeLevelCap(badges);
+        return config.findNextCap(current, badges);
+    }
+
+    public static boolean addBadge(ServerPlayerEntity player, String badgeId, String displayName) {
+        String normalized = config.normalizeKey(badgeId);
+        Set<String> badges = getStoredBadges(player);
+        if (badges.add(normalized)) {
+            saveBadges(player, badges);
+            config.recordDisplayName(normalized, displayName);
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean removeBadge(ServerPlayerEntity player, String badgeId) {
+        String normalized = config.normalizeKey(badgeId);
+        Set<String> badges = getStoredBadges(player);
+        if (badges.remove(normalized)) {
+            saveBadges(player, badges);
+            return true;
+        }
+        return false;
+    }
+
+    public static Set<String> getStoredBadges(ServerPlayerEntity player) {
+        CompoundNBT modData = getOrCreateModData(player);
+        ListNBT list = modData.getList(PLAYER_BADGES_TAG, 8);
+        Set<String> result = new LinkedHashSet<>();
+        for (int i = 0; i < list.size(); i++) {
+            result.add(list.getString(i));
+        }
+        return result;
+    }
+
+    public static void saveBadges(ServerPlayerEntity player, Collection<String> badges) {
+        CompoundNBT modData = getOrCreateModData(player);
+        ListNBT list = new ListNBT();
+        for (String badge : badges) {
+            list.add(StringNBT.valueOf(badge));
+        }
+        modData.put(PLAYER_BADGES_TAG, list);
+        persistModData(player, modData);
+    }
+
+    public static OptionalInt getManualLevelCap(ServerPlayerEntity player) {
+        CompoundNBT modData = getOrCreateModData(player);
+        if (modData.contains(PLAYER_MANUAL_CAP_TAG, 3)) {
+            return OptionalInt.of(Math.max(1, modData.getInt(PLAYER_MANUAL_CAP_TAG)));
+        }
+        return OptionalInt.empty();
+    }
+
+    public static int setManualLevelCap(ServerPlayerEntity player, int levelCap) {
+        CompoundNBT modData = getOrCreateModData(player);
+        int stored = Math.max(1, levelCap);
+        modData.putInt(PLAYER_MANUAL_CAP_TAG, stored);
+        persistModData(player, modData);
+        return stored;
+    }
+
+    public static void cloneBadges(ServerPlayerEntity target, ServerPlayerEntity source) {
+        saveBadges(target, getStoredBadges(source));
+        OptionalInt manual = getManualLevelCap(source);
+        if (manual.isPresent()) {
+            setManualLevelCap(target, manual.getAsInt());
+        } else {
+            clearManualLevelCap(target);
+        }
+    }
+
+    public static void syncBadgesFromPixelmon(ServerPlayerEntity player) {
+        Set<String> normalizedBadges = PixelmonHooks.getBadges(player, badgeName -> {
+            String normalized = config.normalizeKey(badgeName);
+            config.recordDisplayName(normalized, badgeName);
+            return normalized;
+        });
+        saveBadges(player, normalizedBadges);
+    }
+
+    public static void broadcastLevelCap(ServerPlayerEntity player) {
+        int cap = getLevelCap(player);
+        OptionalInt nextCap = getNextCap(player);
+        StringTextComponent message = new StringTextComponent("Your current Pixelmon level cap is " + cap + ".");
+        player.sendMessage(message, player.getUUID());
+        nextCap.ifPresent(value -> player.sendMessage(new StringTextComponent("Your next cap will be " + value + " after earning another configured badge."), player.getUUID()));
+    }
+
+    public static List<String> faintOverCapPokemon(ServerPlayerEntity player) {
+        List<String> fainted = new ArrayList<>();
+        if (player == null) {
+            return fainted;
+        }
+        List<Object> party = PixelmonHooks.getPartyPokemon(player);
+        if (party == null || party.isEmpty()) {
+            return fainted;
+        }
+        int cap = getLevelCap(player);
+        for (Object pokemon : party) {
+            Integer level = PixelmonHooks.getPokemonLevel(pokemon);
+            if (level == null || level <= cap) {
+                continue;
+            }
+            PixelmonHooks.faintPokemon(null, pokemon);
+            fainted.add(PixelmonHooks.getPokemonDisplayName(pokemon));
+        }
+        return fainted;
+    }
+
+    public static GymVictory applyGymVictory(ServerPlayerEntity player, Entity npcEntity) {
+        if (player == null || npcEntity == null || config == null) {
+            return null;
+        }
+        String gymName = trimToNull(PixelmonHooks.getNpcGymName(npcEntity));
+        String leaderName = trimToNull(PixelmonHooks.getNpcLeaderName(npcEntity));
+
+        GymVictory victory = applyGymVictory(player, gymName, gymName);
+        if (victory != null) {
+            if (leaderName != null) {
+                config.recordDisplayName(leaderName, leaderName);
+            }
+            return victory;
+        }
+
+        victory = applyGymVictory(player, leaderName, gymName);
+        if (victory != null) {
+            if (gymName != null) {
+                config.recordDisplayName(gymName, gymName);
+            }
+            return victory;
+        }
+
+        String npcId = npcEntity.getUUID().toString();
+        victory = applyGymVictory(player, npcId, gymName != null ? gymName : leaderName);
+        if (victory != null) {
+            if (gymName != null) {
+                config.recordDisplayName(gymName, gymName);
+            }
+            if (leaderName != null) {
+                config.recordDisplayName(leaderName, leaderName);
+            }
+        }
+        return victory;
+    }
+
+    public static GymVictory applyGymVictory(ServerPlayerEntity player, String alias, String displayHint) {
+        if (player == null || config == null) {
+            return null;
+        }
+        String trimmedAlias = trimToNull(alias);
+        if (trimmedAlias == null) {
+            return null;
+        }
+        GymLevelCapConfig.GymSummary summary = config.findGymSummary(trimmedAlias);
+        if (summary == null) {
+            return null;
+        }
+        String label = summary.getGymName();
+        if (label == null || label.isEmpty()) {
+            label = summary.getLeaderName();
+        }
+        if ((label == null || label.isEmpty()) && displayHint != null) {
+            String hint = trimToNull(displayHint);
+            if (hint != null) {
+                label = hint;
+            }
+        }
+        if (label == null || label.isEmpty()) {
+            label = trimmedAlias;
+        }
+        if (label == null || label.isEmpty()) {
+            label = summary.getId();
+        }
+        if (!addBadge(player, summary.getId(), label)) {
+            return null;
+        }
+        config.recordDisplayName(trimmedAlias, label);
+        int newCap = getLevelCap(player);
+        return new GymVictory(summary, label, newCap);
+    }
+
+    public static List<String> grantGymRewards(ServerPlayerEntity player, GymLevelCapConfig.GymSummary summary) {
+        List<String> granted = new ArrayList<>();
+        if (player == null || summary == null) {
+            return granted;
+        }
+        List<GymLevelCapConfig.ItemReward> rewards = summary.getRewards();
+        if (rewards == null || rewards.isEmpty()) {
+            return granted;
+        }
+        for (GymLevelCapConfig.ItemReward reward : rewards) {
+            ItemStack stack = createRewardStack(reward, summary.getId());
+            if (stack.isEmpty()) {
+                continue;
+            }
+            if (!executeGiveCommand(player, reward, summary.getId())) {
+                continue;
+            }
+            ItemStack displayStack = stack.copy();
+            String displayName = displayStack.getHoverName().getString();
+            int count = displayStack.getCount();
+            if (count <= 1) {
+                granted.add(displayName);
+            } else {
+                granted.add(count + "x " + displayName);
+            }
+        }
+        return granted;
+    }
+
+    private static boolean executeGiveCommand(ServerPlayerEntity player, GymLevelCapConfig.ItemReward reward, String gymId) {
+        MinecraftServer server = player.getServer();
+        if (server == null) {
+            return false;
+        }
+        Commands commands = server.getCommands();
+        if (commands == null) {
+            return false;
+        }
+        CommandSource source = player.createCommandSourceStack().withPermission(4).withSuppressedOutput();
+        String command = buildGiveCommand(player, reward);
+        try {
+            int result = commands.performCommand(source, command);
+            if (result > 0) {
+                return true;
+            }
+            LevelCapMod.LOGGER.warn("Failed to execute /give for reward '{}' from gym '{}'", reward.getItemId(), gymId);
+        } catch (Exception e) {
+            LevelCapMod.LOGGER.warn("Error executing /give for reward '{}' from gym '{}': {}", reward.getItemId(), gymId, e.getMessage());
+        }
+        return false;
+    }
+
+    private static String buildGiveCommand(ServerPlayerEntity player, GymLevelCapConfig.ItemReward reward) {
+        StringBuilder command = new StringBuilder("give ");
+        command.append(player.getScoreboardName()).append(' ');
+        command.append(reward.getItemId());
+        int count = Math.max(1, reward.getCount());
+        if (count > 1) {
+            command.append(' ').append(count);
+        }
+        String nbt = trimToNull(reward.getNbt());
+        if (nbt != null) {
+            command.append(' ').append(nbt);
+        }
+        return command.toString();
+    }
+
+    public static void handleAllOnlinePlayers(java.util.function.Consumer<ServerPlayerEntity> consumer) {
+        if (ServerLifecycleHooks.getCurrentServer() != null) {
+            for (ServerPlayerEntity player : ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers()) {
+                consumer.accept(player);
+            }
+        }
+    }
+
+    public static void beginGymCreation(ServerPlayerEntity player, String gymName, int levelCap) {
+        if (player == null) {
+            return;
+        }
+        String trimmedName = gymName == null ? "" : gymName.trim();
+        pendingGymCreations.put(player.getUUID(), new PendingGymCreation(trimmedName, Math.max(1, levelCap)));
+    }
+
+    public static PendingGymCreation getPendingGymCreation(ServerPlayerEntity player) {
+        if (player == null) {
+            return null;
+        }
+        return pendingGymCreations.get(player.getUUID());
+    }
+
+    public static GymLevelCapConfig.GymSummary completeGymCreation(ServerPlayerEntity player, Entity npcEntity) {
+        if (player == null) {
+            return null;
+        }
+        PendingGymCreation pending = pendingGymCreations.remove(player.getUUID());
+        if (pending == null) {
+            return null;
+        }
+        if (config == null) {
+            pendingGymCreations.put(player.getUUID(), pending);
+            return null;
+        }
+        String leaderName = PixelmonHooks.getNpcLeaderName(npcEntity);
+        String gymName = pending.getGymName();
+        if (gymName == null || gymName.isEmpty()) {
+            gymName = PixelmonHooks.getNpcGymName(npcEntity);
+        }
+        if (gymName == null || gymName.isEmpty()) {
+            gymName = leaderName;
+        }
+        if (gymName == null || gymName.isEmpty()) {
+            gymName = "Gym";
+        }
+        String npcUuid = npcEntity == null ? null : npcEntity.getUUID().toString();
+        GymLevelCapConfig.GymSummary summary = config.createGym(gymName, leaderName, npcUuid, pending.getLevelCap());
+        if (summary != null) {
+            LevelCapMod.LOGGER.info("Created gym '{}' led by '{}' with level cap {} (player: {})",
+                    summary.getGymName(), summary.getLeaderName(), summary.getLevelCap(), player.getGameProfile().getName());
+        }
+        return summary;
+    }
+
+    public static final class PendingGymCreation {
+        private final String gymName;
+        private final int levelCap;
+
+        private PendingGymCreation(String gymName, int levelCap) {
+            this.gymName = gymName;
+            this.levelCap = levelCap;
+        }
+
+        public String getGymName() {
+            return gymName;
+        }
+
+        public int getLevelCap() {
+            return levelCap;
+        }
+    }
+
+    public static final class GymVictory {
+        private final GymLevelCapConfig.GymSummary summary;
+        private final String displayLabel;
+        private final int newLevelCap;
+
+        private GymVictory(GymLevelCapConfig.GymSummary summary, String displayLabel, int newLevelCap) {
+            this.summary = summary;
+            this.displayLabel = displayLabel;
+            this.newLevelCap = newLevelCap;
+        }
+
+        public GymLevelCapConfig.GymSummary getSummary() {
+            return summary;
+        }
+
+        public String getDisplayLabel() {
+            return displayLabel;
+        }
+
+        public int getNewLevelCap() {
+            return newLevelCap;
+        }
+    }
+
+    private static ItemStack createRewardStack(GymLevelCapConfig.ItemReward reward, String gymId) {
+        if (reward == null || reward.getItemId() == null) {
+            return ItemStack.EMPTY;
+        }
+        ResourceLocation id;
+        try {
+            id = new ResourceLocation(reward.getItemId());
+        } catch (ResourceLocationException e) {
+            LevelCapMod.LOGGER.warn("Skipping reward item '{}' for gym '{}': invalid identifier", reward.getItemId(), gymId);
+            return ItemStack.EMPTY;
+        }
+        Item item = ForgeRegistries.ITEMS.getValue(id);
+        if (item == null) {
+            LevelCapMod.LOGGER.warn("Skipping reward item '{}' for gym '{}': item not found", reward.getItemId(), gymId);
+            return ItemStack.EMPTY;
+        }
+        ItemStack stack = new ItemStack(item, Math.max(1, reward.getCount()));
+        String nbt = reward.getNbt();
+        if (nbt != null && !nbt.isEmpty()) {
+            try {
+                stack.setTag(JsonToNBT.parseTag(nbt));
+            } catch (CommandSyntaxException e) {
+                LevelCapMod.LOGGER.warn("Skipping NBT on reward item '{}' for gym '{}': {}", reward.getItemId(), gymId, e.getMessage());
+            }
+        }
+        return stack;
+    }
+
+    private static CompoundNBT getOrCreateModData(ServerPlayerEntity player) {
+        CompoundNBT persistent = player.getPersistentData();
+        CompoundNBT persisted = getOrCreatePersistedTag(persistent);
+        if (persisted.contains(PLAYER_DATA_TAG, 10)) {
+            return persisted.getCompound(PLAYER_DATA_TAG);
+        }
+        CompoundNBT modData = new CompoundNBT();
+        persisted.put(PLAYER_DATA_TAG, modData);
+        persistent.put(PlayerEntity.PERSISTED_NBT_TAG, persisted);
+        return modData;
+    }
+
+    private static void persistModData(ServerPlayerEntity player, CompoundNBT modData) {
+        CompoundNBT persistent = player.getPersistentData();
+        CompoundNBT persisted = getOrCreatePersistedTag(persistent);
+        persisted.put(PLAYER_DATA_TAG, modData);
+        persistent.put(PlayerEntity.PERSISTED_NBT_TAG, persisted);
+    }
+
+    public static void clearManualLevelCap(ServerPlayerEntity player) {
+        CompoundNBT modData = getOrCreateModData(player);
+        if (modData.contains(PLAYER_MANUAL_CAP_TAG)) {
+            modData.remove(PLAYER_MANUAL_CAP_TAG);
+            persistModData(player, modData);
+        }
+    }
+
+    private static CompoundNBT getOrCreatePersistedTag(CompoundNBT persistent) {
+        if (persistent.contains(PlayerEntity.PERSISTED_NBT_TAG, 10)) {
+            return persistent.getCompound(PlayerEntity.PERSISTED_NBT_TAG);
+        }
+        CompoundNBT persisted = new CompoundNBT();
+        persistent.put(PlayerEntity.PERSISTED_NBT_TAG, persisted);
+        return persisted;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/src/main/java/com/example/lvlcap/LevelCapMod.java
+++ b/src/main/java/com/example/lvlcap/LevelCapMod.java
@@ -1,0 +1,76 @@
+package com.example.lvlcap;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
+import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(LevelCapMod.MOD_ID)
+public class LevelCapMod {
+    public static final String MOD_ID = "lvlcap";
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    private final PixelmonEventHandler pixelmonEventHandler = new PixelmonEventHandler();
+
+    public LevelCapMod() {
+        ModLoadingContext.get().registerConfig(net.minecraftforge.fml.config.ModConfig.Type.SERVER, ModConfigHolder.SPEC);
+
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        modEventBus.addListener(this::onCommonSetup);
+        modEventBus.addListener(this::onConfigLoading);
+        modEventBus.addListener(this::onConfigReloading);
+
+        MinecraftForge.EVENT_BUS.register(pixelmonEventHandler);
+        PixelmonHooks.registerPixelmonEventHandler(pixelmonEventHandler);
+        MinecraftForge.EVENT_BUS.addListener(EventPriority.NORMAL, this::onRegisterCommands);
+        MinecraftForge.EVENT_BUS.addListener(this::onServerAboutToStart);
+        MinecraftForge.EVENT_BUS.addListener(this::onServerStarting);
+        MinecraftForge.EVENT_BUS.addListener(this::onServerStopping);
+
+        LevelCapManager.initialize(FMLPaths.CONFIGDIR.get());
+    }
+
+    private void onCommonSetup(final FMLCommonSetupEvent event) {
+        LevelCapMod.LOGGER.info("Pixelmon Level Cap mod initialising");
+        PermissionNodes.register();
+    }
+
+    private void onConfigLoading(final ModConfig.Loading event) {
+        if (event.getConfig().getSpec() == ModConfigHolder.SPEC) {
+            LevelCapManager.reload();
+        }
+    }
+
+    private void onConfigReloading(final ModConfig.Reloading event) {
+        if (event.getConfig().getSpec() == ModConfigHolder.SPEC) {
+            LevelCapManager.reload();
+        }
+    }
+
+    private void onRegisterCommands(final RegisterCommandsEvent event) {
+        LevelCapCommands.register(event.getDispatcher());
+    }
+
+    private void onServerAboutToStart(final FMLServerAboutToStartEvent event) {
+        LevelCapManager.reload();
+    }
+
+    private void onServerStarting(final FMLServerStartingEvent event) {
+        LevelCapManager.reload();
+    }
+
+    private void onServerStopping(final FMLServerStoppingEvent event) {
+        LevelCapManager.saveConfig();
+    }
+}

--- a/src/main/java/com/example/lvlcap/ModConfigHolder.java
+++ b/src/main/java/com/example/lvlcap/ModConfigHolder.java
@@ -1,0 +1,25 @@
+package com.example.lvlcap;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public final class ModConfigHolder {
+    public static final ForgeConfigSpec SPEC;
+    public static final ForgeConfigSpec.IntValue BASE_LEVEL_CAP;
+
+    static {
+        ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        builder.push("level_cap");
+        BASE_LEVEL_CAP = builder
+                .comment("Default level cap for players that have not earned any gym badges.")
+                .defineInRange("baseLevelCap", 20, 1, 1000);
+        builder.pop();
+        SPEC = builder.build();
+    }
+
+    private ModConfigHolder() {
+    }
+
+    public static int getBaseLevelCap() {
+        return BASE_LEVEL_CAP.get();
+    }
+}

--- a/src/main/java/com/example/lvlcap/PermissionNodes.java
+++ b/src/main/java/com/example/lvlcap/PermissionNodes.java
@@ -1,0 +1,59 @@
+package com.example.lvlcap;
+
+import net.minecraft.command.CommandSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.server.permission.DefaultPermissionLevel;
+import net.minecraftforge.server.permission.PermissionAPI;
+
+/**
+ * Centralises permission node declarations for the mod's commands.
+ */
+public final class PermissionNodes {
+    public static final String COMMAND_VIEW = "lvlcap.command.view";
+    public static final String COMMAND_FAINT_SELF = "lvlcap.command.faint";
+    public static final String COMMAND_FAINT_OTHERS = "lvlcap.command.faint.others";
+    public static final String COMMAND_SET = "lvlcap.command.set";
+    public static final String COMMAND_INCREASE = "lvlcap.command.increase";
+    public static final String COMMAND_REMOVE = "lvlcap.command.remove";
+    public static final String COMMAND_LIST = "lvlcap.command.list";
+    public static final String COMMAND_SPAWN = "lvlcap.command.spawn";
+    public static final String COMMAND_CREATE = "lvlcap.command.create";
+
+    private PermissionNodes() {
+    }
+
+    public static void register() {
+        PermissionAPI.registerNode(COMMAND_VIEW, DefaultPermissionLevel.ALL, "Allows using /lvlcap to view the cap.");
+        PermissionAPI.registerNode(COMMAND_FAINT_SELF, DefaultPermissionLevel.ALL,
+                "Allows using /lvlcap faint on yourself.");
+        PermissionAPI.registerNode(COMMAND_FAINT_OTHERS, DefaultPermissionLevel.OP,
+                "Allows using /lvlcap faint on other players.");
+        PermissionAPI.registerNode(COMMAND_SET, DefaultPermissionLevel.OP,
+                "Allows setting gym level caps with /lvlcap set.");
+        PermissionAPI.registerNode(COMMAND_INCREASE, DefaultPermissionLevel.OP,
+                "Allows increasing player level caps with /lvlcap increase.");
+        PermissionAPI.registerNode(COMMAND_REMOVE, DefaultPermissionLevel.OP,
+                "Allows removing gym level caps with /lvlcap remove.");
+        PermissionAPI.registerNode(COMMAND_LIST, DefaultPermissionLevel.OP,
+                "Allows listing configured caps with /lvlcap list.");
+        PermissionAPI.registerNode(COMMAND_SPAWN, DefaultPermissionLevel.OP,
+                "Allows spawning gym NPCs with /lvlcap spawn.");
+        PermissionAPI.registerNode(COMMAND_CREATE, DefaultPermissionLevel.OP,
+                "Allows creating gyms with /create gym.");
+    }
+
+    public static boolean canUse(CommandSource source, String node, int requiredLevel) {
+        if (source.hasPermission(requiredLevel)) {
+            return true;
+        }
+
+        final PlayerEntity player = source.getEntity() instanceof PlayerEntity
+                ? (PlayerEntity) source.getEntity()
+                : null;
+        return player != null && PermissionAPI.hasPermission(player, node);
+    }
+
+    public static boolean canUse(CommandSource source, String node) {
+        return canUse(source, node, 0);
+    }
+}

--- a/src/main/java/com/example/lvlcap/PixelmonEventHandler.java
+++ b/src/main/java/com/example/lvlcap/PixelmonEventHandler.java
@@ -1,0 +1,236 @@
+package com.example.lvlcap;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class PixelmonEventHandler {
+    @SubscribeEvent
+    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getPlayer() instanceof ServerPlayerEntity)) {
+            return;
+        }
+        ServerPlayerEntity player = (ServerPlayerEntity) event.getPlayer();
+        if (player.level.isClientSide) {
+            return;
+        }
+        LevelCapManager.syncBadgesFromPixelmon(player);
+        LevelCapManager.broadcastLevelCap(player);
+    }
+
+    @SubscribeEvent
+    public void onPlayerClone(PlayerEvent.Clone event) {
+        if (!(event.getPlayer() instanceof ServerPlayerEntity)) {
+            return;
+        }
+        ServerPlayerEntity player = (ServerPlayerEntity) event.getPlayer();
+        if (player.level.isClientSide) {
+            return;
+        }
+        if (event.getOriginal() instanceof ServerPlayerEntity) {
+            LevelCapManager.cloneBadges(player, (ServerPlayerEntity) event.getOriginal());
+        }
+        LevelCapManager.broadcastLevelCap(player);
+    }
+
+    @SubscribeEvent
+    public void onPixelmonEvents(Event event) {
+        String packageName = event.getClass().getName();
+        if (!packageName.startsWith("com.pixelmonmod")) {
+            return;
+        }
+        String simpleName = event.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+        if (simpleName.contains("badge")) {
+            if (simpleName.contains("receive") || simpleName.contains("earn") || simpleName.contains("gain")) {
+                handleBadgeEvent(event, true);
+            } else if (simpleName.contains("remove") || simpleName.contains("lost") || simpleName.contains("lose")) {
+                handleBadgeEvent(event, false);
+            }
+        }
+        if (simpleName.contains("battle") && (simpleName.contains("start")
+                || simpleName.contains("begin") || simpleName.contains("init"))) {
+            handleBattleStart(event);
+        }
+        if ((simpleName.contains("battle") && (simpleName.contains("win") || simpleName.contains("victor")
+                || simpleName.contains("end") || simpleName.contains("finish") || simpleName.contains("result")))
+                || simpleName.contains("victory") || simpleName.contains("defeat") || simpleName.contains("beat")) {
+            handleGymVictory(event);
+        }
+        if (simpleName.contains("sendout") || simpleName.contains("sentout")) {
+            handleSendOut(event);
+        }
+    }
+
+    private void handleBadgeEvent(Event event, boolean earned) {
+        ServerPlayerEntity player = PixelmonHooks.getPlayerFromEvent(event);
+        if (player == null || player.level.isClientSide) {
+            return;
+        }
+        String badgeName = PixelmonHooks.extractBadgeName(event);
+        if (badgeName == null || badgeName.isEmpty()) {
+            LevelCapMod.LOGGER.debug("Pixelmon badge event {} did not contain a badge name", event.getClass().getName());
+            return;
+        }
+        boolean changed;
+        if (earned) {
+            changed = LevelCapManager.addBadge(player, badgeName, badgeName);
+        } else {
+            changed = LevelCapManager.removeBadge(player, badgeName);
+        }
+        if (!changed) {
+            return;
+        }
+        int cap = LevelCapManager.getLevelCap(player);
+        if (earned) {
+            player.sendMessage(new StringTextComponent("Your badge from " + badgeName + " raised the level cap to " + cap + "."), player.getUUID());
+        } else {
+            player.sendMessage(new StringTextComponent("Your level cap is now " + cap + " after losing the " + badgeName + " badge."), player.getUUID());
+        }
+        LevelCapManager.broadcastLevelCap(player);
+    }
+
+    private void handleSendOut(Event event) {
+        ServerPlayerEntity player = PixelmonHooks.getPlayerFromEvent(event);
+        if (player == null || player.level.isClientSide) {
+            return;
+        }
+        if (!PixelmonHooks.isBattleSendOut(event)) {
+            return;
+        }
+        Object pokemon = PixelmonHooks.getPokemonFromEvent(event);
+        Integer level = PixelmonHooks.getPokemonLevel(pokemon);
+        if (level == null) {
+            return;
+        }
+        int cap = LevelCapManager.getLevelCap(player);
+        if (level > cap) {
+            PixelmonHooks.faintPokemon(event, pokemon);
+            String name = PixelmonHooks.getPokemonDisplayName(pokemon);
+            player.sendMessage(new StringTextComponent(name + " fainted for exceeding the level cap of " + cap + "."), player.getUUID());
+        }
+    }
+
+    private void handleBattleStart(Event event) {
+        List<ServerPlayerEntity> players = PixelmonHooks.getPlayersFromEvent(event);
+        if (players.isEmpty()) {
+            ServerPlayerEntity single = PixelmonHooks.getPlayerFromEvent(event);
+            if (single != null) {
+                players = java.util.Collections.singletonList(single);
+            }
+        }
+        for (ServerPlayerEntity player : players) {
+            if (player == null || player.level.isClientSide) {
+                continue;
+            }
+            List<String> fainted = LevelCapManager.faintOverCapPokemon(player);
+            if (fainted.isEmpty()) {
+                continue;
+            }
+            String joined = String.join(", ", fainted);
+            player.sendMessage(new StringTextComponent("Fainted " + fainted.size()
+                    + " over-cap Pokémon before battle: " + joined + "."), player.getUUID());
+        }
+    }
+
+    private void handleGymVictory(Event event) {
+        List<ServerPlayerEntity> winners = PixelmonHooks.getWinningPlayers(event);
+        if (winners.isEmpty()) {
+            return;
+        }
+        List<Entity> trainers = PixelmonHooks.getGymLeadersFromEvent(event);
+        String badgeName = PixelmonHooks.extractBadgeName(event);
+        for (ServerPlayerEntity winner : winners) {
+            if (winner == null || winner.level.isClientSide) {
+                continue;
+            }
+            List<LevelCapManager.GymVictory> victories = new ArrayList<>();
+            for (Entity trainer : trainers) {
+                LevelCapManager.GymVictory victory = LevelCapManager.applyGymVictory(winner, trainer);
+                if (victory != null) {
+                    victories.add(victory);
+                }
+            }
+            if (victories.isEmpty() && badgeName != null && !badgeName.isEmpty()) {
+                LevelCapManager.GymVictory victory = LevelCapManager.applyGymVictory(winner, badgeName, badgeName);
+                if (victory != null) {
+                    victories.add(victory);
+                }
+            }
+            if (victories.isEmpty()) {
+                continue;
+            }
+            for (LevelCapManager.GymVictory victory : victories) {
+                String label = victory.getDisplayLabel();
+                if (label == null || label.isEmpty()) {
+                    label = badgeName;
+                }
+                if (label == null || label.isEmpty()) {
+                    label = "the gym";
+                }
+                int cap = victory.getNewLevelCap();
+                if (cap <= 0) {
+                    cap = LevelCapManager.getLevelCap(winner);
+                }
+                winner.sendMessage(new StringTextComponent("Defeating " + label
+                        + " raised your level cap to " + cap + "."), winner.getUUID());
+                List<String> rewards = LevelCapManager.grantGymRewards(winner, victory.getSummary());
+                if (!rewards.isEmpty()) {
+                    winner.sendMessage(new StringTextComponent("You received: "
+                            + String.join(", ", rewards) + "."), winner.getUUID());
+                }
+            }
+            LevelCapManager.broadcastLevelCap(winner);
+        }
+    }
+
+    @SubscribeEvent
+    public void onNpcInteract(PlayerInteractEvent.EntityInteract event) {
+        if (!(event.getPlayer() instanceof ServerPlayerEntity)) {
+            return;
+        }
+        ServerPlayerEntity player = (ServerPlayerEntity) event.getPlayer();
+        if (player.level.isClientSide) {
+            return;
+        }
+        LevelCapManager.PendingGymCreation pending = LevelCapManager.getPendingGymCreation(player);
+        if (pending == null) {
+            return;
+        }
+        if (!PixelmonHooks.isPixelmonNpc(event.getTarget())) {
+            String pendingName = pending.getGymName();
+            if (pendingName == null || pendingName.isEmpty()) {
+                pendingName = "gym";
+            }
+            player.sendMessage(new StringTextComponent("That isn't a Pixelmon NPC. Right-click the gym leader to finish creating \""
+                    + pendingName + "\"."), player.getUUID());
+            return;
+        }
+        GymLevelCapConfig.GymSummary summary = LevelCapManager.completeGymCreation(player, event.getTarget());
+        if (summary == null) {
+            player.sendMessage(new StringTextComponent("Failed to create the gym. Please try again."), player.getUUID());
+            return;
+        }
+        String gymLabel = summary.getGymName();
+        if (gymLabel == null || gymLabel.isEmpty()) {
+            gymLabel = summary.getLeaderName();
+        }
+        if (gymLabel == null || gymLabel.isEmpty()) {
+            gymLabel = "Gym";
+        }
+        String leaderLabel = summary.getLeaderName();
+        if (leaderLabel == null || leaderLabel.isEmpty()) {
+            leaderLabel = PixelmonHooks.getNpcDisplayName(event.getTarget());
+        }
+        player.sendMessage(new StringTextComponent("Created gym \"" + gymLabel + "\" led by \"" + leaderLabel
+                + "\" with a level cap of " + summary.getLevelCap() + "."), player.getUUID());
+        LevelCapManager.handleAllOnlinePlayers(LevelCapManager::broadcastLevelCap);
+    }
+}

--- a/src/main/java/com/example/lvlcap/PixelmonHooks.java
+++ b/src/main/java/com/example/lvlcap/PixelmonHooks.java
@@ -1,0 +1,999 @@
+package com.example.lvlcap;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.Optional;
+
+public final class PixelmonHooks {
+    private PixelmonHooks() {
+    }
+
+    private static Class<?>[] npcBaseClasses;
+    private static boolean npcClassLookupAttempted;
+    private static EntityType<?> cachedNpcEntityType;
+    private static boolean npcEntityTypeLookupAttempted;
+    private static Object pixelmonEventBus;
+    private static boolean pixelmonEventBusLookupAttempted;
+    private static final String[] ENTITY_METHOD_NAMES = new String[] {
+            "getEntity", "getTrainer", "getTrainers", "getOpponent", "getOpponents",
+            "getOpposingTrainer", "getOpposingTrainers", "getOpponentTrainer", "getTargets",
+            "getTarget", "getParticipants", "getChallengers", "getLeaders", "getGymLeader",
+            "getGymLeaders", "getNpc", "getNPC", "getNpcs", "getNPCs", "getNonPlayerParticipants",
+            "getOtherTrainers", "getBattleOpponents", "getBattleOpponent", "getDefendingTrainers",
+            "getDefenders", "getAllTrainers", "getAllParticipants", "getBattle", "getBattleController"
+    };
+    private static final String[] ENTITY_FIELD_NAMES = new String[] {
+            "entity", "trainer", "trainers", "opponent", "opponents", "opposingTrainer",
+            "opposingTrainers", "npc", "npcTrainer", "npcEntity", "target", "targets", "leader",
+            "leaders", "gymLeader", "gymLeaders", "challenger", "challengers", "participant",
+            "participants", "battleOpponents", "enemyTrainers", "defenders"
+    };
+    private static final String[] WINNER_METHOD_NAMES = new String[] {
+            "getWinner", "getWinners", "getWinningPlayer", "getWinningPlayers", "getVictors",
+            "getVictor", "getWinningTrainers", "getWinningTeam", "getWinningChallengers",
+            "getWinningParticipants"
+    };
+    private static final String[] WINNER_FIELD_NAMES = new String[] {
+            "winner", "winners", "winningPlayer", "winningPlayers", "victor", "victors",
+            "winningTrainers", "winningTeam", "winningChallengers", "winningParticipants"
+    };
+
+    public static void registerPixelmonEventHandler(Object handler) {
+        if (handler == null) {
+            return;
+        }
+        Object eventBus = getPixelmonEventBus();
+        if (eventBus == null) {
+            LevelCapMod.LOGGER.warn("Pixelmon event bus not found; cannot register handler {}", handler.getClass().getName());
+            return;
+        }
+        try {
+            Method register = eventBus.getClass().getMethod("register", Object.class);
+            register.invoke(eventBus, handler);
+        } catch (ReflectiveOperationException e) {
+            LevelCapMod.LOGGER.warn("Failed to register Pixelmon event handler {}: {}", handler.getClass().getName(), e.getMessage());
+        }
+    }
+
+    private static Object getPixelmonEventBus() {
+        if (!pixelmonEventBusLookupAttempted) {
+            pixelmonEventBusLookupAttempted = true;
+            try {
+                Class<?> pixelmonClass = Class.forName("com.pixelmonmod.pixelmon.Pixelmon");
+                Field field = pixelmonClass.getField("EVENT_BUS");
+                pixelmonEventBus = field.get(null);
+            } catch (ClassNotFoundException e) {
+                LevelCapMod.LOGGER.warn("Pixelmon not detected on the classpath; gym victories will not be tracked");
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                LevelCapMod.LOGGER.warn("Unable to access Pixelmon EVENT_BUS: {}", e.getMessage());
+            }
+        }
+        return pixelmonEventBus;
+    }
+
+    public static ServerPlayerEntity getPlayerFromEvent(Event event) {
+        Object candidate = invokeOptional(event, "getPlayer");
+        if (candidate instanceof ServerPlayerEntity) {
+            return (ServerPlayerEntity) candidate;
+        }
+        candidate = invokeOptional(event, "getPlayerMP");
+        if (candidate instanceof ServerPlayerEntity) {
+            return (ServerPlayerEntity) candidate;
+        }
+        candidate = invokeOptional(event, "getPlayerEntity");
+        if (candidate instanceof ServerPlayerEntity) {
+            return (ServerPlayerEntity) candidate;
+        }
+        Object field = getFieldValue(event, "player", "playerMP", "playerEntity");
+        if (field instanceof ServerPlayerEntity) {
+            return (ServerPlayerEntity) field;
+        }
+        return null;
+    }
+
+    public static List<ServerPlayerEntity> getPlayersFromEvent(Event event) {
+        Set<ServerPlayerEntity> players = new LinkedHashSet<>();
+        if (event == null) {
+            return new ArrayList<>();
+        }
+        ServerPlayerEntity direct = getPlayerFromEvent(event);
+        if (direct != null) {
+            players.add(direct);
+        }
+        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        visited.add(event);
+        collectPlayerCandidates(invokeOptional(event, "getPlayers"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getPlayerList"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getAllPlayers"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getBattlers"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getParticipants"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getTrainers"), players, visited);
+        collectPlayerCandidates(getFieldValue(event, "players", "playerList", "challengers", "participants",
+                "trainers", "battlers"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getBattle"), players, visited);
+        collectPlayerCandidates(invokeOptional(event, "getBattleController"), players, visited);
+        return new ArrayList<>(players);
+    }
+
+    public static List<ServerPlayerEntity> getWinningPlayers(Event event) {
+        Set<ServerPlayerEntity> winners = new LinkedHashSet<>();
+        if (event == null) {
+            return new ArrayList<>();
+        }
+        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        visited.add(event);
+        for (String method : WINNER_METHOD_NAMES) {
+            collectPlayerCandidates(invokeOptional(event, method), winners, visited);
+        }
+        for (String field : WINNER_FIELD_NAMES) {
+            collectPlayerCandidates(getFieldValue(event, field), winners, visited);
+        }
+        if (winners.isEmpty() && playerWon(event)) {
+            ServerPlayerEntity player = getPlayerFromEvent(event);
+            if (player != null) {
+                winners.add(player);
+            }
+        }
+        return new ArrayList<>(winners);
+    }
+
+    public static List<Entity> getGymLeadersFromEvent(Event event) {
+        List<Entity> entities = getEntitiesFromEvent(event);
+        List<Entity> trainers = new ArrayList<>();
+        for (Entity entity : entities) {
+            if (entity != null && isPixelmonNpc(entity)) {
+                trainers.add(entity);
+            }
+        }
+        return trainers;
+    }
+
+    private static void collectPlayerCandidates(Object candidate, Set<ServerPlayerEntity> players, Set<Object> visited) {
+        if (candidate == null) {
+            return;
+        }
+        if (candidate instanceof ServerPlayerEntity) {
+            players.add((ServerPlayerEntity) candidate);
+            return;
+        }
+        if (!visited.add(candidate)) {
+            return;
+        }
+        if (candidate instanceof Collection<?>) {
+            for (Object element : (Collection<?>) candidate) {
+                collectPlayerCandidates(element, players, visited);
+            }
+            return;
+        }
+        if (candidate.getClass().isArray()) {
+            int length = Array.getLength(candidate);
+            for (int i = 0; i < length; i++) {
+                collectPlayerCandidates(Array.get(candidate, i), players, visited);
+            }
+            return;
+        }
+        Object extracted = invokeOptional(candidate, "getPlayer");
+        if (extracted != null) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getPlayerEntity");
+        if (extracted != null) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getPlayerMP");
+        if (extracted != null) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getEntity");
+        if (extracted != null) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = getFieldValue(candidate, "player", "playerEntity", "playerMP", "entity");
+        if (extracted != null) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getPlayers");
+        if (extracted != null && extracted != candidate) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getPlayerList");
+        if (extracted != null && extracted != candidate) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = invokeOptional(candidate, "getAllPlayers");
+        if (extracted != null && extracted != candidate) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+        extracted = getFieldValue(candidate, "players", "playerList", "participants", "trainers", "challengers", "battlers");
+        if (extracted != null && extracted != candidate) {
+            collectPlayerCandidates(extracted, players, visited);
+        }
+    }
+
+    public static String extractBadgeName(Event event) {
+        Object badgeObject = invokeOptional(event, "getBadge");
+        if (badgeObject == null) {
+            badgeObject = getFieldValue(event, "badge", "badgeID", "badgeName");
+        }
+        if (badgeObject != null) {
+            String identified = identifyBadge(badgeObject);
+            if (identified != null) {
+                return identified;
+            }
+        }
+        Object name = invokeOptional(event, "getBadgeName");
+        if (name == null) {
+            name = invokeOptional(event, "getGymName");
+        }
+        if (name == null) {
+            name = invokeOptional(event, "getLeaderName");
+        }
+        if (name == null) {
+            name = getFieldValue(event, "gymName", "leaderName");
+        }
+        return name == null ? null : name.toString();
+    }
+
+    public static Set<String> getBadges(ServerPlayerEntity player, Function<String, String> normalizer) {
+        Set<String> badges = new LinkedHashSet<>();
+        try {
+            Class<?> storageProxy = Class.forName("com.pixelmonmod.pixelmon.api.storage.StorageProxy");
+            Method getParty = findCompatibleMethod(storageProxy, "getParty", ServerPlayerEntity.class);
+            if (getParty == null) {
+                getParty = findCompatibleMethod(storageProxy, "getParty", Class.forName("net.minecraft.entity.player.PlayerEntity"));
+            }
+            if (getParty == null) {
+                LevelCapMod.LOGGER.debug("Unable to find StorageProxy#getParty; badge sync skipped");
+                return badges;
+            }
+            Object storage = getParty.invoke(null, player);
+            if (storage == null) {
+                return badges;
+            }
+            Object badgeCase = invokeOptional(storage, "getBadgeCase");
+            if (badgeCase == null) {
+                badgeCase = invokeOptional(storage, "getBadges");
+            }
+            Collection<?> badgeCollection = extractBadgeCollection(badgeCase);
+            for (Object badge : badgeCollection) {
+                String identified = identifyBadge(badge);
+                if (identified != null && !identified.isEmpty()) {
+                    badges.add(normalizer.apply(identified));
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            LevelCapMod.LOGGER.debug("Pixelmon StorageProxy class not found; assuming Pixelmon is unavailable");
+        } catch (Exception e) {
+            LevelCapMod.LOGGER.error("Failed to synchronise Pixelmon badges for {}", player.getGameProfile().getName(), e);
+        }
+        return badges;
+    }
+
+    public static boolean isBattleSendOut(Event event) {
+        Boolean flag = toBoolean(invokeOptional(event, "isBattle"));
+        if (flag != null) {
+            return flag;
+        }
+        if (invokeOptional(event, "getBattleController") != null) {
+            return true;
+        }
+        if (invokeOptional(event, "getBattle") != null) {
+            return true;
+        }
+        Object context = invokeOptional(event, "getContext");
+        if (context != null) {
+            String simpleName = context.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+            if (simpleName.contains("battle")) {
+                return true;
+            }
+        }
+        String simple = event.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+        return simple.contains("battle");
+    }
+
+    public static Object getPokemonFromEvent(Event event) {
+        Object pokemon = invokeOptional(event, "getPokemon");
+        if (pokemon == null) {
+            pokemon = getFieldValue(event, "pokemon", "storagePokemon");
+        }
+        return pokemon;
+    }
+
+    public static Integer getPokemonLevel(Object pokemon) {
+        if (pokemon == null) {
+            return null;
+        }
+        Object value = invokeOptional(pokemon, "getPokemonLevel");
+        if (!(value instanceof Number)) {
+            value = invokeOptional(pokemon, "getLevel");
+        }
+        if (!(value instanceof Number)) {
+            value = invokeOptional(pokemon, "getLvl");
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return null;
+    }
+
+    public static String getPokemonDisplayName(Object pokemon) {
+        if (pokemon == null) {
+            return "Pokemon";
+        }
+        Object name = invokeOptional(pokemon, "getDisplayName");
+        if (name == null) {
+            name = invokeOptional(pokemon, "getLocalizedName");
+        }
+        if (name == null) {
+            name = invokeOptional(pokemon, "getName");
+        }
+        if (name == null) {
+            name = getFieldValue(pokemon, "nickname", "pokemonName", "localizedName");
+        }
+        return name == null ? "Pokemon" : name.toString();
+    }
+
+    public static List<Object> getPartyPokemon(ServerPlayerEntity player) {
+        List<Object> pokemon = new ArrayList<>();
+        if (player == null) {
+            return pokemon;
+        }
+        try {
+            Class<?> storageProxy = Class.forName("com.pixelmonmod.pixelmon.api.storage.StorageProxy");
+            Method getParty = findCompatibleMethod(storageProxy, "getParty", ServerPlayerEntity.class);
+            if (getParty == null) {
+                getParty = findCompatibleMethod(storageProxy, "getParty",
+                        Class.forName("net.minecraft.entity.player.PlayerEntity"));
+            }
+            if (getParty == null) {
+                LevelCapMod.LOGGER.debug("Unable to locate StorageProxy#getParty; party lookup skipped");
+                return pokemon;
+            }
+            Object partyStorage = getParty.invoke(null, player);
+            if (partyStorage == null) {
+                return pokemon;
+            }
+            Collection<?> collection = extractPartyCollection(partyStorage);
+            for (Object entry : collection) {
+                if (entry != null) {
+                    pokemon.add(entry);
+                }
+            }
+            if (pokemon.isEmpty()) {
+                collectPartySlots(partyStorage, pokemon);
+            }
+        } catch (ClassNotFoundException e) {
+            LevelCapMod.LOGGER.debug("Pixelmon StorageProxy class not found; assuming Pixelmon is unavailable");
+        } catch (Exception e) {
+            LevelCapMod.LOGGER.error("Failed to inspect Pixelmon party for {}",
+                    player.getGameProfile().getName(), e);
+        }
+        return pokemon;
+    }
+
+    public static boolean isPixelmonNpc(Entity entity) {
+        if (entity == null) {
+            return false;
+        }
+        ensureNpcClassesLoaded();
+        if (npcBaseClasses != null) {
+            for (Class<?> npcClass : npcBaseClasses) {
+                if (npcClass.isInstance(entity)) {
+                    return true;
+                }
+            }
+        }
+        String name = entity.getClass().getName().toLowerCase(Locale.ROOT);
+        return name.contains("pixelmon") && (name.contains("npc") || name.contains("trainer"));
+    }
+
+    public static String getNpcGymName(Entity entity) {
+        if (entity == null) {
+            return null;
+        }
+        Object gymName = invokeOptional(entity, "getGymName");
+        if (gymName == null) {
+            gymName = invokeOptional(entity, "getArenaName");
+        }
+        if (gymName == null) {
+            gymName = invokeOptional(entity, "getGymTitle");
+        }
+        if (gymName == null) {
+            gymName = getFieldValue(entity, "gymName", "arenaName", "gymTitle");
+        }
+        String text = toText(gymName);
+        return text == null || text.isEmpty() ? null : text;
+    }
+
+    public static String getNpcLeaderName(Entity entity) {
+        if (entity == null) {
+            return null;
+        }
+        Object leader = invokeOptional(entity, "getLeaderName");
+        if (leader == null) {
+            leader = invokeOptional(entity, "getTrainerName");
+        }
+        if (leader == null) {
+            leader = invokeOptional(entity, "getName");
+        }
+        if (leader == null) {
+            leader = getFieldValue(entity, "leaderName", "trainerName", "name");
+        }
+        String text = toText(leader);
+        if (text != null && !text.isEmpty()) {
+            return text;
+        }
+        ITextComponent displayName = entity.getDisplayName();
+        if (displayName != null) {
+            text = displayName.getString();
+            if (!text.isEmpty()) {
+                return text;
+            }
+        }
+        return entity.getName().getString();
+    }
+
+    public static String getNpcDisplayName(Entity entity) {
+        if (entity == null) {
+            return "NPC";
+        }
+        ITextComponent displayName = entity.getDisplayName();
+        if (displayName != null) {
+            String text = displayName.getString();
+            if (!text.isEmpty()) {
+                return text;
+            }
+        }
+        return entity.getName().getString();
+    }
+
+    public static Entity spawnGymNpc(ServerPlayerEntity player, String gymName, String leaderName, int levelCap) {
+        if (player == null || !(player.level instanceof ServerWorld)) {
+            return null;
+        }
+        ServerWorld world = (ServerWorld) player.level;
+        EntityType<?> type = resolvePixelmonNpcEntityType();
+        if (type == null) {
+            return null;
+        }
+        Entity entity;
+        try {
+            entity = type.create(world);
+        } catch (Exception e) {
+            LevelCapMod.LOGGER.error("Failed to instantiate Pixelmon NPC entity for gym spawn", e);
+            return null;
+        }
+        if (entity == null) {
+            LevelCapMod.LOGGER.warn("Pixelmon NPC entity type {} returned null when spawning", ForgeRegistries.ENTITIES.getKey(type));
+            return null;
+        }
+        Direction facing = player.getDirection();
+        BlockPos targetPos = player.blockPosition().relative(facing);
+        double x = targetPos.getX() + 0.5d;
+        double y = targetPos.getY();
+        double z = targetPos.getZ() + 0.5d;
+        entity.moveTo(x, y, z, player.yRot, player.xRot);
+        LivingEntity living = null;
+        if (entity instanceof LivingEntity) {
+            living = (LivingEntity) entity;
+            if (entity instanceof MobEntity) {
+                ((MobEntity) entity).setPersistenceRequired();
+            }
+            living.yHeadRot = player.yRot;
+            living.yBodyRot = player.yRot;
+        }
+        applyGymMetadata(entity, gymName, leaderName, levelCap);
+        if (living != null) {
+            String custom = leaderName;
+            if (custom == null || custom.trim().isEmpty()) {
+                custom = gymName;
+            }
+            if (custom == null || custom.trim().isEmpty()) {
+                custom = getNpcDisplayName(entity);
+            }
+            if (custom != null && !custom.trim().isEmpty()) {
+                living.setCustomName(new StringTextComponent(custom.trim()));
+                living.setCustomNameVisible(true);
+            }
+        }
+        world.addFreshEntity(entity);
+        return entity;
+    }
+
+    public static void faintPokemon(Event event, Object pokemon) {
+        if (pokemon == null) {
+            return;
+        }
+        invokeOptional(pokemon, "setHealth", 0);
+        invokeOptional(pokemon, "setHealth", 0.0f);
+        invokeOptional(pokemon, "setHealth", 0.0d);
+        invokeOptional(pokemon, "setFainted", true);
+        Object battlePokemon = invokeOptional(pokemon, "getBattlePokemon");
+        if (battlePokemon != null) {
+            invokeOptional(battlePokemon, "setHealth", 0);
+            invokeOptional(battlePokemon, "setHealth", 0.0f);
+            invokeOptional(battlePokemon, "setHealth", 0.0d);
+            invokeOptional(battlePokemon, "setFainted", true);
+        }
+        Object entity = invokeOptional(event, "getEntity");
+        if (entity == null) {
+            entity = getFieldValue(event, "entity", "pokemonEntity");
+        }
+        if (entity instanceof LivingEntity) {
+            ((LivingEntity) entity).setHealth(0.0f);
+        }
+    }
+
+    private static List<Entity> getEntitiesFromEvent(Event event) {
+        Set<Entity> entities = new LinkedHashSet<>();
+        if (event == null) {
+            return new ArrayList<>();
+        }
+        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        visited.add(event);
+        collectEntityCandidates(event, entities, visited);
+        return new ArrayList<>(entities);
+    }
+
+    private static void collectEntityCandidates(Object candidate, Set<Entity> entities, Set<Object> visited) {
+        if (candidate == null) {
+            return;
+        }
+        if (candidate instanceof Entity) {
+            entities.add((Entity) candidate);
+            return;
+        }
+        if (!visited.add(candidate)) {
+            return;
+        }
+        if (candidate instanceof Collection<?>) {
+            for (Object element : (Collection<?>) candidate) {
+                collectEntityCandidates(element, entities, visited);
+            }
+            return;
+        }
+        if (candidate.getClass().isArray()) {
+            int length = Array.getLength(candidate);
+            for (int i = 0; i < length; i++) {
+                collectEntityCandidates(Array.get(candidate, i), entities, visited);
+            }
+            return;
+        }
+        for (String method : ENTITY_METHOD_NAMES) {
+            collectEntityCandidates(invokeOptional(candidate, method), entities, visited);
+        }
+        for (String field : ENTITY_FIELD_NAMES) {
+            collectEntityCandidates(getFieldValue(candidate, field), entities, visited);
+        }
+    }
+
+    private static boolean playerWon(Event event) {
+        if (event == null) {
+            return false;
+        }
+        String[] flags = new String[] {"didPlayerWin", "didWin", "isPlayerWinner", "playerWon", "challengerWon"};
+        for (String name : flags) {
+            Boolean flag = toBoolean(invokeOptional(event, name));
+            if (flag != null) {
+                return flag;
+            }
+        }
+        for (String name : flags) {
+            Boolean flag = toBoolean(getFieldValue(event, name));
+            if (flag != null) {
+                return flag;
+            }
+        }
+        return false;
+    }
+
+    private static void applyGymMetadata(Entity entity, String gymName, String leaderName, int levelCap) {
+        if (entity == null) {
+            return;
+        }
+        String trimmedGym = gymName == null ? "" : gymName.trim();
+        String trimmedLeader = leaderName == null ? "" : leaderName.trim();
+        if (!trimmedGym.isEmpty()) {
+            invokeOptional(entity, "setGymName", trimmedGym);
+            invokeOptional(entity, "setArenaName", trimmedGym);
+            invokeOptional(entity, "setGymTitle", trimmedGym);
+        }
+        if (!trimmedLeader.isEmpty()) {
+            invokeOptional(entity, "setLeaderName", trimmedLeader);
+            invokeOptional(entity, "setTrainerName", trimmedLeader);
+            invokeOptional(entity, "setName", trimmedLeader);
+        }
+        if (levelCap > 0) {
+            invokeOptional(entity, "setLevelCap", levelCap);
+            invokeOptional(entity, "setLevel", levelCap);
+            invokeOptional(entity, "setTrainerLevel", levelCap);
+            invokeOptional(entity, "setMinLevel", levelCap);
+            invokeOptional(entity, "setMaxLevel", levelCap);
+        }
+    }
+
+    private static EntityType<?> resolvePixelmonNpcEntityType() {
+        if (cachedNpcEntityType != null) {
+            return cachedNpcEntityType;
+        }
+        if (npcEntityTypeLookupAttempted) {
+            return null;
+        }
+        npcEntityTypeLookupAttempted = true;
+        EntityType<?> best = null;
+        int bestScore = -1;
+        for (EntityType<?> type : ForgeRegistries.ENTITIES.getValues()) {
+            ResourceLocation key = ForgeRegistries.ENTITIES.getKey(type);
+            if (key == null || !"pixelmon".equals(key.getNamespace())) {
+                continue;
+            }
+            String path = key.getPath().toLowerCase(Locale.ROOT);
+            int score = 0;
+            if (path.contains("gym")) {
+                score = 3;
+            } else if (path.contains("trainer")) {
+                score = 2;
+            } else if (path.contains("npc")) {
+                score = 1;
+            }
+            if (score <= 0) {
+                continue;
+            }
+            if (score > bestScore) {
+                best = type;
+                bestScore = score;
+            }
+        }
+        if (best != null) {
+            cachedNpcEntityType = best;
+            return cachedNpcEntityType;
+        }
+        String[] fallbacks = new String[] {"pixelmon:gym_leader", "pixelmon:npc_trainer", "pixelmon:npc_battle", "pixelmon:npc"};
+        for (String id : fallbacks) {
+            Optional<EntityType<?>> optional = EntityType.byString(id);
+            if (optional.isPresent()) {
+                cachedNpcEntityType = optional.get();
+                break;
+            }
+        }
+        if (cachedNpcEntityType == null) {
+            LevelCapMod.LOGGER.warn("No Pixelmon NPC entity types were found in the registry; gym spawning is unavailable.");
+        }
+        return cachedNpcEntityType;
+    }
+
+    private static Collection<?> extractBadgeCollection(Object badgeCase) {
+        if (badgeCase == null) {
+            return Collections.emptyList();
+        }
+        if (badgeCase instanceof Collection) {
+            return (Collection<?>) badgeCase;
+        }
+        Object result = invokeOptional(badgeCase, "getBadges");
+        if (!(result instanceof Collection)) {
+            result = invokeOptional(badgeCase, "getBadgeList");
+        }
+        if (!(result instanceof Collection)) {
+            result = invokeOptional(badgeCase, "values");
+        }
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        Object field = getFieldValue(badgeCase, "badges", "badgeList", "entries");
+        if (field instanceof Collection) {
+            return (Collection<?>) field;
+        }
+        if (field != null && field.getClass().isArray()) {
+            return arrayToCollection(field);
+        }
+        return Collections.emptyList();
+    }
+
+    private static Collection<?> extractPartyCollection(Object partyStorage) {
+        if (partyStorage == null) {
+            return Collections.emptyList();
+        }
+        Object result = invokeOptional(partyStorage, "getTeam");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        result = invokeOptional(partyStorage, "getPokemonList");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        result = invokeOptional(partyStorage, "getPartyPokemon");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        result = invokeOptional(partyStorage, "getAll");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        result = invokeOptional(partyStorage, "getAllPokemon");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        result = invokeOptional(partyStorage, "getPokemons");
+        if (result instanceof Collection) {
+            return (Collection<?>) result;
+        }
+        if (result != null && result.getClass().isArray()) {
+            return arrayToCollection(result);
+        }
+        Object field = getFieldValue(partyStorage, "partyPokemon", "pokemonList", "team", "party", "teamPokemon");
+        if (field instanceof Collection) {
+            return (Collection<?>) field;
+        }
+        if (field != null && field.getClass().isArray()) {
+            return arrayToCollection(field);
+        }
+        return Collections.emptyList();
+    }
+
+    private static void collectPartySlots(Object partyStorage, List<Object> target) {
+        for (int i = 0; i < 6; i++) {
+            Object entry = invokeOptional(partyStorage, "getPokemon", i);
+            if (entry == null) {
+                entry = invokeOptional(partyStorage, "get", i);
+            }
+            if (entry == null) {
+                entry = invokeOptional(partyStorage, "getTeamSlot", i);
+            }
+            if (entry == null) {
+                entry = invokeOptional(partyStorage, "getSlot", i);
+            }
+            if (entry != null) {
+                target.add(entry);
+            }
+        }
+    }
+
+    private static Collection<?> arrayToCollection(Object array) {
+        int length = Array.getLength(array);
+        List<Object> values = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            values.add(Array.get(array, i));
+        }
+        return values;
+    }
+
+    private static String identifyBadge(Object badgeObject) {
+        if (badgeObject == null) {
+            return null;
+        }
+        if (badgeObject instanceof String) {
+            return badgeObject.toString();
+        }
+        if (badgeObject instanceof Enum<?>) {
+            return ((Enum<?>) badgeObject).name();
+        }
+        Object name = invokeOptional(badgeObject, "getBadgeName");
+        if (name == null) {
+            name = invokeOptional(badgeObject, "getIdentifier");
+        }
+        if (name == null) {
+            name = invokeOptional(badgeObject, "getName");
+        }
+        if (name == null) {
+            name = invokeOptional(badgeObject, "getDisplayName");
+        }
+        if (name == null) {
+            name = getFieldValue(badgeObject, "badgeName", "identifier", "name", "displayName");
+        }
+        return name == null ? badgeObject.toString() : name.toString();
+    }
+
+    private static Object invokeOptional(Object target, String methodName, Object... args) {
+        if (target == null) {
+            return null;
+        }
+        Method method = findMethod(target.getClass(), methodName, args);
+        if (method == null) {
+            return null;
+        }
+        try {
+            method.setAccessible(true);
+            return method.invoke(target, args);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Method findMethod(Class<?> type, String methodName, Object... args) {
+        Class<?> current = type;
+        while (current != null) {
+            for (Method method : current.getDeclaredMethods()) {
+                if (!method.getName().equals(methodName)) {
+                    continue;
+                }
+                if (method.getParameterCount() != args.length) {
+                    continue;
+                }
+                Class<?>[] parameters = method.getParameterTypes();
+                boolean matches = true;
+                for (int i = 0; i < parameters.length; i++) {
+                    if (args[i] != null && !wrap(parameters[i]).isInstance(args[i])) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) {
+                    return method;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private static Method findCompatibleMethod(Class<?> type, String name, Class<?>... parameterHints) {
+        Class<?> current = type;
+        while (current != null) {
+            for (Method method : current.getDeclaredMethods()) {
+                if (!method.getName().equals(name)) {
+                    continue;
+                }
+                Class<?>[] params = method.getParameterTypes();
+                if (params.length != parameterHints.length) {
+                    continue;
+                }
+                boolean matches = true;
+                for (int i = 0; i < params.length; i++) {
+                    if (!params[i].isAssignableFrom(parameterHints[i])) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) {
+                    method.setAccessible(true);
+                    return method;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private static Class<?> wrap(Class<?> clazz) {
+        if (!clazz.isPrimitive()) {
+            return clazz;
+        }
+        if (clazz == int.class) {
+            return Integer.class;
+        }
+        if (clazz == float.class) {
+            return Float.class;
+        }
+        if (clazz == double.class) {
+            return Double.class;
+        }
+        if (clazz == long.class) {
+            return Long.class;
+        }
+        if (clazz == boolean.class) {
+            return Boolean.class;
+        }
+        if (clazz == short.class) {
+            return Short.class;
+        }
+        if (clazz == byte.class) {
+            return Byte.class;
+        }
+        if (clazz == char.class) {
+            return Character.class;
+        }
+        return clazz;
+    }
+
+    private static Object getFieldValue(Object target, String... names) {
+        if (target == null) {
+            return null;
+        }
+        for (String name : names) {
+            Field field = findField(target.getClass(), name);
+            if (field != null) {
+                try {
+                    field.setAccessible(true);
+                    return field.get(target);
+                } catch (IllegalAccessException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Field findField(Class<?> type, String name) {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                Field field = current.getDeclaredField(name);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private static Boolean toBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        return null;
+    }
+
+    private static void ensureNpcClassesLoaded() {
+        if (npcClassLookupAttempted) {
+            return;
+        }
+        npcClassLookupAttempted = true;
+        List<Class<?>> classes = new ArrayList<>();
+        String[] candidates = new String[] {
+                "com.pixelmonmod.pixelmon.entities.npcs.EntityNPC",
+                "com.pixelmonmod.pixelmon.entities.npcs.NPCEntity",
+                "com.pixelmonmod.pixelmon.entities.npcs.EntityNPCTrainer",
+                "com.pixelmonmod.pixelmon.entities.npcs.EntityNPCBattle",
+                "com.pixelmonmod.pixelmon.entities.npcs.trainers.EntityTrainer"
+        };
+        for (String className : candidates) {
+            try {
+                classes.add(Class.forName(className));
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+        npcBaseClasses = classes.isEmpty() ? null : classes.toArray(new Class<?>[0]);
+    }
+
+    private static String toText(Object value) {
+        if (value instanceof ITextComponent) {
+            return ((ITextComponent) value).getString();
+        }
+        return value == null ? null : value.toString();
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,37 @@
+modLoader="javafml"
+loaderVersion="[36,)"
+license="MIT"
+issueTrackerURL="https://example.com/issues"
+
+[[mods]]
+modId="lvlcap"
+version="${file.jarVersion}"
+displayName="Pixelmon Level Cap"
+displayURL="https://example.com/"
+logoFile=""
+credits=""
+authors="sidemodsrerforged"
+description='''
+Adds dynamic Pokemon level caps to Pixelmon gyms.
+'''
+
+[[dependencies.lvlcap]]
+    modId="forge"
+    mandatory=true
+    versionRange="[36,)"
+    ordering="NONE"
+    side="SERVER"
+
+[[dependencies.lvlcap]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.16.5]"
+    ordering="NONE"
+    side="SERVER"
+
+[[dependencies.lvlcap]]
+    modId="pixelmon"
+    mandatory=true
+    versionRange="[9.0.0,)"
+    ordering="NONE"
+    side="SERVER"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Pixelmon Level Cap resources",
+    "pack_format": 6
+  }
+}


### PR DESCRIPTION
## Summary
- allow admins to run `/lvlcap increase <player> <level>` to raise a trainer's cap to at least the requested value
- persist manual level-cap overrides in player data so increases survive respawns and badge syncs
- document the new command and permission node in the README

## Testing
- `./gradlew --version`
- `./gradlew build` *(fails: ForgeGradle's Groovy scripts require Java 8; running on Java 21 triggers "Unsupported class file major version 65")*

------
https://chatgpt.com/codex/tasks/task_e_68c9f00c5034833084765707d33d410f